### PR TITLE
Fix critical vision radius bugs in LLMAgent perception system

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,26 @@ import os
 from unittest.mock import Mock, patch
 
 import pytest
+from mesa.model import Model
+from mesa.space import MultiGrid
+
+from mesa_llm.llm_agent import LLMAgent
+from mesa_llm.memory.st_memory import ShortTermMemory
+from mesa_llm.reasoning.react import ReActReasoning
+
+# Module-level constants
+DEFAULT_AGENT_CONFIG = {
+    "reasoning": ReActReasoning,
+    "system_prompt": "Test",
+    "internal_state": ["test"],
+}
+
+
+class MockCell:
+    """Mock cell with coordinate attribute"""
+
+    def __init__(self, coordinate):
+        self.coordinate = coordinate
 
 
 @pytest.fixture(autouse=True)
@@ -9,7 +29,11 @@ def mock_environment():
     """Ensure tests don't depend on real environment variables"""
     with patch.dict(
         os.environ,
-        {"PROVIDER_API_KEY": "test_key", "OPENAI_API_KEY": "test_openai_key"},
+        {
+            "GEMINI_API_KEY": "dummy",
+            "PROVIDER_API_KEY": "test_key",
+            "OPENAI_API_KEY": "test_openai_key",
+        },
         clear=True,
     ):
         yield
@@ -35,3 +59,40 @@ def mock_llm():
         mock_llm_instance = Mock()
         mock_llm_class.return_value = mock_llm_instance
         yield mock_llm_instance
+
+
+@pytest.fixture
+def basic_model():
+    """Create basic model without grid"""
+    return Model(seed=42)
+
+
+@pytest.fixture
+def grid_model():
+    """Create model with MultiGrid"""
+
+    class GridModel(Model):
+        def __init__(self):
+            super().__init__(seed=42)
+            self.grid = MultiGrid(10, 10, torus=False)
+
+    return GridModel()
+
+
+@pytest.fixture
+def basic_agent(basic_model):
+    """Create single agent with memory"""
+    agents = LLMAgent.create_agents(basic_model, n=1, vision=0, **DEFAULT_AGENT_CONFIG)
+    agent = agents[0]
+    agent.memory = ShortTermMemory(agent=agent, n=5, display=True)
+    return agent
+
+
+@pytest.fixture
+def disable_memory(monkeypatch):
+    """Helper to disable memory add_to_memory method"""
+
+    def _disable(agent):
+        monkeypatch.setattr(agent.memory, "add_to_memory", lambda *args, **kwargs: None)
+
+    return _disable


### PR DESCRIPTION
Changes in llm_agent.py
1.Orthogonal Grids Vision Radius - Now properly finds agent cells and respects vision parameter
2.Position Access Robustness - Added safe attribute checking for different grid/agent types
3.SingleGrid/MultiGrid Radius - Fixed hardcoded radius=1 to use actual vision parameter

Changes in test_llm_agent.py
adds targeted patch tests for LLMAgent.generate_obs() to
cover newly introduced vision-based neighborhood logic.

Specifically, it adds tests that exercise:
- vision > 0 behavior on MultiGrid using radius=self.vision
- vision > 0 behavior on OrthogonalMooreGrid using cell neighborhoods
- agent-cell discovery and neighborhood traversal logic

@EwoutH 
