### PR TITLE
Fix STLTMemory consolidation to respect consolidation_capacity batch size

### DIFF
--- a/mesa_llm/memory/st_lt_memory.py
+++ b/mesa_llm/memory/st_lt_memory.py
@@ -134,7 +134,8 @@ class STLTMemory(Memory):
             > self.capacity + (self.consolidation_capacity or 0)
             and self.consolidation_capacity
         ):
-            self.short_term_memory.popleft()
+            for _ in range(self.consolidation_capacity):
+                self.short_term_memory.popleft()
             should_consolidate = True
 
         elif (

--- a/tests/test_memory/test_STLT_memory.py
+++ b/tests/test_memory/test_STLT_memory.py
@@ -1,5 +1,5 @@
 from collections import deque
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from mesa_llm.memory.memory import MemoryEntry
 from mesa_llm.memory.st_lt_memory import STLTMemory
@@ -143,3 +143,42 @@ class TestSTLTMemory:
 
         # Verify last observation is tracked
         assert memory.last_observation == obs2
+
+    def test_batch_size_fix(self, mock_agent):
+        """
+        A minimal test to check whether stlt memory pops out the consolidation batches properly.
+        """
+        new_entry = STLTMemory(
+            agent=mock_agent,
+            short_term_capacity=2,
+            consolidation_capacity=3,
+            llm_model="provider/test_model",
+        )
+        new_entry.llm.generate = Mock(return_value="summary")
+        new_entry.agent.model.steps = 0
+
+        # Populate with 5 sample values
+        for i in range(5):
+            new_entry.short_term_memory.append(
+                MemoryEntry(agent=new_entry.agent, content={"v": i}, step=i)
+            )
+
+        # Add the 6th item via process_step to trigger the logic
+        # New state: size will be 6. (6 > 5) triggers consolidation.
+
+        new_entry.step_content = {"v": 5}
+
+        new_entry.process_step(pre_step=True)
+        new_entry.agent.model.steps = 5
+        new_entry.process_step(pre_step=False)
+
+        # We started with 6 items total
+        # If the fix works: 6 - 3 (Batch) = 3 items should remain.
+        # If the bug exists: 6 - 1 (Old behavior) = 5 items will remain.
+
+        actual_count = len(new_entry.short_term_memory)
+        print(actual_count)
+        assert actual_count == 3, (
+            f"FAILED: Expected 3 items left, but found {actual_count}."
+            f"The fix loop did not remove the full batch of 3!"
+        )


### PR DESCRIPTION
### Summary

This PR fixes an issue in `STLTMemory` where `consolidation_capacity` was not properly respected as a batch size during consolidation. Previously, consolidation removed only a single entry per cycle, even when consolidation_capacity was configured to remove multiple entries.

This resulted in inefficient short-term memory cleanup and inconsistent behavior relative to the documented design.

### Bug / Issue
Fixes #77 

The `STLTMemory` class documentation states that `consolidation_capacity` controls the number of entries to summarize when short-term memory exceeds its effective limit.

**Expected behavior:**
When STM size exceeds` short_term_capacity + consolidation_capacity`, the memory system should remove and consolidate `consolidation_capacity` entries at once.

**Actual behavior:**
Only one entry was being removed during each consolidation cycle, effectively treating consolidation_capacity as a threshold trigger rather than a batch size.

This caused:
- STM to remain in an overflow state for multiple steps
- Consolidation to be slower and less efficient
- Behavior inconsistent with documentation

### Implementation

Changes made:

- Updated the consolidation logic inside _process_step_core in STLTMemory.
- Modified the removal behavior to correctly pop consolidation_capacity entries using a loop:
- Ensured consolidation is triggered only when:
          `len(self.short_term_memory) > self.capacity + self.consolidation_capacity`
- Added a unit test (`test_batch_size_fix`) to explicitly verify correct batch removal behavior.

### Additional Notes

- This change improves memory management efficiency.