### PR TITLE
fix: suppress spurious Auto-save failed warning from atexit in tests

### DIFF
--- a/mesa_llm/recording/record_model.py
+++ b/mesa_llm/recording/record_model.py
@@ -83,10 +83,7 @@ def record_model(
         def _auto_save():
             try:
                 # Avoid creating multiple identical files if already saved manually
-                # Use getattr so that a replaced/mock recorder without an `events`
-                # attribute does not raise AttributeError here.
-                recorder = getattr(self, "recorder", None)
-                if recorder is not None and getattr(recorder, "events", None):
+                if hasattr(self, "recorder") and self.recorder.events:
                     self.save_recording()
             except Exception as exc:  # pragma: no cover - defensive
                 print(f"[SimulationRecorder] Auto-save failed: {exc}")

--- a/mesa_llm/recording/record_model.py
+++ b/mesa_llm/recording/record_model.py
@@ -83,7 +83,10 @@ def record_model(
         def _auto_save():
             try:
                 # Avoid creating multiple identical files if already saved manually
-                if hasattr(self, "recorder") and self.recorder.events:
+                # Use getattr so that a replaced/mock recorder without an `events`
+                # attribute does not raise AttributeError here.
+                recorder = getattr(self, "recorder", None)
+                if recorder is not None and getattr(recorder, "events", None):
                     self.save_recording()
             except Exception as exc:  # pragma: no cover - defensive
                 print(f"[SimulationRecorder] Auto-save failed: {exc}")

--- a/tests/test_recording/test_record_model.py
+++ b/tests/test_recording/test_record_model.py
@@ -126,6 +126,7 @@ class TestRecordModelDecorator:
 
         # Mock the recorder to track calls
         model.recorder = Mock(spec=SimulationRecorder)
+        model.recorder.events = []  # instance attr not in class spec; set explicitly
 
         # Call step
         model.step()


### PR DESCRIPTION
### Summary

After every test run a `[SimulationRecorder] Auto-save failed: Mock object has no attribute 'events'` warning was printed to stdout even though all tests passed. This PR fixes the root cause in the production code and patches the incomplete test mock that triggered it.

---

### Bug / Issue

Closes #83 

The `record_model` decorator registers an `atexit` handler (`_auto_save`) for every model it wraps — including ones created inside the test suite. One test (`test_step_method_wrapping_basic`) replaces the real recorder with a `Mock(spec=SimulationRecorder)` after model init, but `spec=` only mirrors the **class-level** attributes, not instance-level ones like `self.events`. When Python shuts down and `atexit` fires, `_auto_save` tries to access `self.recorder.events`, hits `AttributeError`, falls into the `except` block, and prints the warning.

---

### Implementation

Two small changes:

**record_model.py** — made `_auto_save` genuinely defensive:

```python
# Before
if hasattr(self, "recorder") and self.recorder.events:

# After — getattr guards against any recorder substitute that lacks .events
recorder = getattr(self, "recorder", None)
if recorder is not None and getattr(recorder, "events", None):
```

This way the closure can never raise `AttributeError` regardless of what has been assigned to `self.recorder`.

**test_record_model.py** — completed the mock after it's assigned:

```python
model.recorder = Mock(spec=SimulationRecorder)
model.recorder.events = []  # instance attr not in class spec; set explicitly
```

`events` is set in `__init__`, so `spec=SimulationRecorder` doesn't include it. Setting it explicitly makes the mock match what the real object looks like at runtime.

---

### Testing

```bash
pytest --cov=mesa_llm tests/
```

Before this fix:
```
177 passed in 9.24s
[SimulationRecorder] Auto-save failed: Mock object has no attribute 'events'
```
<img width="451" height="33" alt="image" src="https://github.com/user-attachments/assets/8295c6b9-8819-47f7-9cc7-0afa66fac143" />

After this fix:
```
177 passed in 9.74s
```

No tests changed their pass/fail status. No coverage regression (overall stays at 88%).
<img width="451" height="43" alt="image" src="https://github.com/user-attachments/assets/6b28afa3-1fed-4c76-b824-77c3202fa7dd" />

---

### Additional Notes

- No behaviour change for real `SimulationRecorder` instances in production — `getattr(recorder, "events", None)` returns the real list just the same.
- The `atexit` registration per model instance is a separate design question (registering many handlers in a long test run). That's out of scope here and worth a follow-up discussion if needed.