### PR TITLE
Validate llm_model format in ModuleLLM

### DIFF
--- a/mesa_llm/module_llm.py
+++ b/mesa_llm/module_llm.py
@@ -44,6 +44,13 @@ class ModuleLLM:
         self.api_base = api_base
         self.llm_model = llm_model
         self.system_prompt = system_prompt
+
+        if "/" not in llm_model:
+            raise ValueError(
+                f"Invalid model format '{llm_model}'. "
+                "Expected '{provider}/{model}', e.g. 'openai/gpt-4o'."
+            )
+
         provider = self.llm_model.split("/")[0].upper()
 
         if provider in ["OLLAMA", "OLLAMA_CHAT"]:

--- a/mesa_llm/module_llm.py
+++ b/mesa_llm/module_llm.py
@@ -37,9 +37,14 @@ class ModuleLLM:
         Initialize the LLM module
 
         Args:
-            llm_model: The model to use for the LLM in the format of {provider}/{LLM}
+            llm_model: The model to use for the LLM in the format
+                "{provider}/{model}" (for example, "openai/gpt-4o").
             api_base: The API base to use if the LLM provider is Ollama
             system_prompt: The system prompt to use for the LLM
+
+        Raises:
+            ValueError: If llm_model is not in the expected "{provider}/{model}"
+                format, or if the provider API key is missing.
         """
         self.api_base = api_base
         self.llm_model = llm_model

--- a/tests/test_module_llm.py
+++ b/tests/test_module_llm.py
@@ -28,6 +28,11 @@ def mock_api_key():
 class TestModuleLLM:
     """Test ModuleLLM class"""
 
+    def test_missing_provider_prefix(self):
+        """ModuleLLM should raise ValueError when llm_model has no provider prefix."""
+        with pytest.raises(ValueError, match="Invalid model format"):
+            ModuleLLM(llm_model="gpt-4o")
+
     def test_module_llm_initialization(self, mock_api_key):
         # Test initialization with default values
         llm = ModuleLLM(llm_model="openai/gpt-4o")


### PR DESCRIPTION
Fixes #88

Adds early validation for llm_model format and a unit test for this case.
