### PR TITLE
fix: allow None for prompt in get_messages, generate, agenerate

### DIFF
--- a/mesa_llm/module_llm.py
+++ b/mesa_llm/module_llm.py
@@ -65,12 +65,12 @@ class ModuleLLM:
                 f"[yellow][Warning]: {self.llm_model} does not support function calling. This model may not be able to use tools. Please check the model documentation at https://docs.litellm.ai/docs/providers for more information.[/yellow]"
             )
 
-    def get_messages(self, prompt: str | list[str]) -> list[dict]:
+    def get_messages(self, prompt: str | list[str] | None = None) -> list[dict]:
         """
         Format the prompt messages for the LLM of the form : {"role": ..., "content": ...}
 
         Args:
-            prompt: The prompt to generate a response for
+            prompt: The prompt to generate a response for (str, list of strings, or None)
 
         Returns:
             The messages for the LLM
@@ -97,7 +97,7 @@ class ModuleLLM:
     )
     def generate(
         self,
-        prompt: str | list[str],
+        prompt: str | list[str] | None = None,
         tool_schema: list[dict] | None = None,
         tool_choice: str = "auto",
         response_format: dict | object | None = None,
@@ -106,7 +106,7 @@ class ModuleLLM:
         Generate a response from the LLM using litellm based on the prompt
 
         Args:
-            prompt: The prompt to generate a response for
+            prompt: The prompt to generate a response for (str, list of strings, or None)
             tool_schema: The schema of the tools to use
             tool_choice: The choice of tool to use
             response_format: The format of the response
@@ -142,7 +142,7 @@ class ModuleLLM:
 
     async def agenerate(
         self,
-        prompt: str | list[str],
+        prompt: str | list[str] | None = None,
         tool_schema: list[dict] | None = None,
         tool_choice: str = "auto",
         response_format: dict | object | None = None,

--- a/mesa_llm/module_llm.py
+++ b/mesa_llm/module_llm.py
@@ -65,7 +65,7 @@ class ModuleLLM:
                 f"[yellow][Warning]: {self.llm_model} does not support function calling. This model may not be able to use tools. Please check the model documentation at https://docs.litellm.ai/docs/providers for more information.[/yellow]"
             )
 
-    def get_messages(self, prompt: str | list[str] | None = None) -> list[dict]:
+    def _build_messages(self, prompt: str | list[str] | None = None) -> list[dict]:
         """
         Format the prompt messages for the LLM of the form : {"role": ..., "content": ...}
 
@@ -115,7 +115,7 @@ class ModuleLLM:
             The response from the LLM
         """
 
-        messages = self.get_messages(prompt)
+        messages = self._build_messages(prompt)
 
         # If api_base is provided, use it to override the default API base
         if self.api_base:
@@ -150,7 +150,7 @@ class ModuleLLM:
         """
         Asynchronous version of generate() method for parallel LLM calls.
         """
-        messages = self.get_messages(prompt)
+        messages = self._build_messages(prompt)
         async for attempt in AsyncRetrying(
             wait=wait_exponential(multiplier=1, min=1, max=60),
             retry=retry_if_exception_type(RETRYABLE_EXCEPTIONS),

--- a/tests/test_module_llm.py
+++ b/tests/test_module_llm.py
@@ -52,17 +52,17 @@ class TestModuleLLM:
         with patch.dict(os.environ, {}, clear=True), pytest.raises(ValueError):
             ModuleLLM(llm_model="openai/gpt-4o")
 
-    def test_get_messages(self):
-        # Test get_messages with string prompt
+    def test_build_messages(self):
+        # Test _build_messages with string prompt
         llm = ModuleLLM(llm_model="openai/gpt-4o")
-        messages = llm.get_messages("Hello, how are you?")
+        messages = llm._build_messages("Hello, how are you?")
         assert messages == [
             {"role": "system", "content": ""},
             {"role": "user", "content": "Hello, how are you?"},
         ]
 
-        # Test get_messages with list of prompts
-        messages = llm.get_messages(
+        # Test _build_messages with list of prompts
+        messages = llm._build_messages(
             ["Hello, how are you?", "What is the weather in Tokyo?"]
         )
         assert messages == [
@@ -71,18 +71,18 @@ class TestModuleLLM:
             {"role": "user", "content": "What is the weather in Tokyo?"},
         ]
 
-        # Test get_messages with system prompt
+        # Test _build_messages with system prompt
         llm = ModuleLLM(
             llm_model="openai/gpt-4o", system_prompt="You are a helpful assistant."
         )
-        messages = llm.get_messages("Hello, how are you?")
+        messages = llm._build_messages("Hello, how are you?")
         assert messages == [
             {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": "Hello, how are you?"},
         ]
 
-        # Test get_messages with system prompt and list of prompts
-        messages = llm.get_messages(
+        # Test _build_messages with system prompt and list of prompts
+        messages = llm._build_messages(
             ["Hello, how are you?", "What is the weather in Tokyo?"]
         )
         assert messages == [
@@ -91,9 +91,9 @@ class TestModuleLLM:
             {"role": "user", "content": "What is the weather in Tokyo?"},
         ]
 
-        # Test get_messages no system prompt and no prompt
+        # Test _build_messages no system prompt and no prompt
         llm = ModuleLLM(llm_model="openai/gpt-4o")
-        messages = llm.get_messages(prompt=None)
+        messages = llm._build_messages(prompt=None)
         assert messages == [{"role": "system", "content": ""}]
 
     def test_generate(self, monkeypatch):


### PR DESCRIPTION
fixes #91 
get_messages(), generate(), and agenerate() silently accepted None for prompt at runtime but the type hint said str | list[str], causing a mypy error. Updated all three signatures to str | list[str] | None = None to match the actual behavior.