### PR TITLE
Remove duplicate entries in __all__ in mesa_llm.__init__

### DIFF
--- a/mesa_llm/__init__.py
+++ b/mesa_llm/__init__.py
@@ -21,8 +21,6 @@ __all__ = [
     "enable_automatic_parallel_stepping",
     "record_model",
     "step_agents_parallel",
-    "step_agents_parallel",
-    "step_agents_parallel_sync",
     "step_agents_parallel_sync",
 ]
 


### PR DESCRIPTION
Remove duplicate exports from **all**

This PR removes redundant entries for "step_agents_parallel" and "step_agents_parallel_sync"
that were listed twice in the module's public API. Keeping each export once makes the code
cleaner and easier to maintain.

<img width="1108" height="572" alt="image" src="https://github.com/user-attachments/assets/fa4211b9-af66-4932-897a-f797b06cd05f" />