### PR TITLE
fix: the fail tests, replace to_list() with next(iter(...)) on AgentSet

### DIFF
--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -33,7 +33,7 @@ def test_apply_plan_adds_to_memory(monkeypatch):
 
             x, y = pos
 
-            agent = agents.to_list()[0]
+            agent = next(iter(agents))
             self.grid.place_agent(agent, (x, y))
             return agent
 
@@ -87,7 +87,7 @@ def test_generate_obs_with_one_neighbor(monkeypatch):
                 internal_state=["test_state"],
             )
             x, y = pos
-            agent = agents.to_list()[0]
+            agent = next(iter(agents))
             self.grid.place_agent(agent, (x, y))
             return agent
 
@@ -145,7 +145,7 @@ def test_send_message_updates_both_agents_memory(monkeypatch):
                 internal_state=["test_state"],
             )
             x, y = pos
-            agent = agents.to_list()[0]
+            agent = next(iter(agents))
             self.grid.place_agent(agent, (x, y))
             return agent
 
@@ -205,7 +205,7 @@ async def test_aapply_plan_adds_to_memory(monkeypatch):
             )
 
             x, y = pos
-            agent = agents.to_list()[0]
+            agent = next(iter(agents))
             self.grid.place_agent(agent, (x, y))
             return agent
 
@@ -252,7 +252,7 @@ async def test_agenerate_obs_with_one_neighbor(monkeypatch):
                 internal_state=["test_state"],
             )
             x, y = pos
-            agent = agents.to_list()[0]
+            agent = next(iter(agents))
             self.grid.place_agent(agent, (x, y))
             return agent
 
@@ -305,7 +305,8 @@ async def test_async_wrapper_calls_pre_and_post(monkeypatch):
         system_prompt="test",
         vision=-1,
         internal_state=[],
-    ).to_list()[0]
+    )
+    agent = next(iter(agent))
 
     calls = {"pre": 0, "post": 0}
 


### PR DESCRIPTION
Fix AttributeError raised in [test_llm_agent.py](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) when calling .to_list() on an AgentSet object (closes #97). The current version of mesa's AgentSet doesn't expose a to_list() method, so all 6 affected tests were failing. Replaced all occurrences of .to_list()[0] with [next(iter(...))](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) since AgentSet is iterable.
- the test before the modification
<img width="811" height="450" alt="image" src="https://github.com/user-attachments/assets/d90c152a-cd3d-422d-9b2e-b2bc9fcefe4c" />

- the test after the modification
<img width="777" height="394" alt="image" src="https://github.com/user-attachments/assets/b2bb4e52-c278-4bfc-90e2-f74df4aa6810" />
