### PR TITLE
fix: extract text content from LLM response in memory consolidation

### DIFF
--- a/mesa_llm/memory/lt_memory.py
+++ b/mesa_llm/memory/lt_memory.py
@@ -63,14 +63,16 @@ class LongTermMemory(Memory):
         Update the long term memory by summarizing the short term memory with a LLM
         """
         prompt = self._build_consolidation_prompt()
-        self.long_term_memory = self.llm.generate(prompt)
+        response = self.llm.generate(prompt)
+        self.long_term_memory = response.choices[0].message.content
 
     async def _aupdate_long_term_memory(self):
         """
         Asynchronous version of _update_long_term_memory
         """
         prompt = self._build_consolidation_prompt()
-        self.long_term_memory = await self.llm.agenerate(prompt)
+        response = await self.llm.agenerate(prompt)
+        self.long_term_memory = response.choices[0].message.content
 
     def process_step(self, pre_step: bool = False):
         """

--- a/mesa_llm/memory/st_lt_memory.py
+++ b/mesa_llm/memory/st_lt_memory.py
@@ -88,14 +88,16 @@ class STLTMemory(Memory):
         Update the long term memory by summarizing the short term memory with a LLM
         """
         prompt = self._build_consolidation_prompt()
-        self.long_term_memory = self.llm.generate(prompt)
+        response = self.llm.generate(prompt)
+        self.long_term_memory = response.choices[0].message.content
 
     async def _aupdate_long_term_memory(self):
         """
         Async Function to update long term memory
         """
         prompt = self._build_consolidation_prompt()
-        self.long_term_memory = await self.llm.agenerate(prompt)
+        response = await self.llm.agenerate(prompt)
+        self.long_term_memory = response.choices[0].message.content
 
     def _process_step_core(self, pre_step: bool):
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,7 @@ def llm_response_factory():
     return build_llm_response
 
 
+@pytest.fixture
 def basic_model():
     """Create basic model without grid"""
     return Model(seed=42)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,34 @@ import os
 from unittest.mock import Mock, patch
 
 import pytest
+from litellm import Choices, Message, ModelResponse
+
+
+def build_llm_response(
+    content: str = "ok",
+    *,
+    role: str = "assistant",
+    tool_calls: list | None = None,
+    response_id: str = "mock-response-id",
+    model: str = "openai/mock-model",
+    created: int = 0,
+) -> ModelResponse:
+    """Create a typed LiteLLM response object for tests."""
+    return ModelResponse(
+        id=response_id,
+        created=created,
+        model=model,
+        object="chat.completion",
+        choices=[
+            Choices(
+                message=Message(
+                    role=role,
+                    content=content,
+                    tool_calls=tool_calls,
+                )
+            )
+        ],
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -24,7 +52,9 @@ def mock_agent():
     agent.__str__ = Mock(return_value="TestAgent(123)")
     agent.model = Mock()
     agent.model.steps = 1
+    agent.model.events = []
     agent.step_prompt = "Test step prompt"
+    agent.llm = Mock()
     return agent
 
 
@@ -35,3 +65,9 @@ def mock_llm():
         mock_llm_instance = Mock()
         mock_llm_class.return_value = mock_llm_instance
         yield mock_llm_instance
+
+
+@pytest.fixture
+def llm_response_factory():
+    """Fixture wrapper around typed LiteLLM response builder."""
+    return build_llm_response

--- a/tests/test_memory/test_STLT_memory.py
+++ b/tests/test_memory/test_STLT_memory.py
@@ -1,5 +1,5 @@
 from collections import deque
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from mesa_llm.memory.memory import MemoryEntry
 from mesa_llm.memory.st_lt_memory import STLTMemory
@@ -58,7 +58,10 @@ class TestSTLTMemory:
 
     def test_memory_consolidation(self, mock_agent, mock_llm):
         """Test memory consolidation when capacity is exceeded"""
-        mock_llm.generate.return_value = "Consolidated memory summary"
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Consolidated memory summary"
+        mock_llm.generate.return_value = mock_response
 
         memory = STLTMemory(
             agent=mock_agent,
@@ -108,23 +111,49 @@ class TestSTLTMemory:
         assert memory.format_long_term() == "Long-term summary"
 
     def test_update_long_term_memory(self, mock_agent, mock_llm):
-        """Test long-term memory update process"""
-        mock_llm.generate.return_value = "Updated long-term memory"
+        """Check that after consolidation, long_term_memory holds the actual
+        text from the LLM response, not some object."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Updated long-term memory"
+        mock_llm.generate.return_value = mock_response
 
         memory = STLTMemory(agent=mock_agent, llm_model="provider/test_model")
-        # Replace the real LLM with our mock
         memory.llm = mock_llm
         memory.long_term_memory = "Previous memory"
 
         memory._update_long_term_memory()
 
-        # Verify LLM was called with correct prompt structure
         call_args = mock_llm.generate.call_args[0][0]
         assert "Short term memory:" in call_args
         assert "Long term memory:" in call_args
         assert "Previous memory" in call_args
 
+        # Must be a plain string, not a ModelResponse object
+        assert isinstance(memory.long_term_memory, str)
         assert memory.long_term_memory == "Updated long-term memory"
+
+    def test_long_term_memory_stores_string_not_response_object(
+        self, mock_agent, mock_llm
+    ):
+        """Make sure long_term_memory is always a plain string.
+        Before this fix, it was storing the whole LLM response object instead
+        of just the text — which broke any prompt that used the memory.
+        """
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "This is the summary text"
+        mock_llm.generate.return_value = mock_response
+
+        memory = STLTMemory(agent=mock_agent, llm_model="provider/test_model")
+        memory.llm = mock_llm
+
+        memory._update_long_term_memory()
+
+        assert isinstance(memory.long_term_memory, str), (
+            "long_term_memory must be a string, not a ModelResponse object"
+        )
+        assert memory.long_term_memory == "This is the summary text"
 
     def test_observation_tracking(self, mock_agent):
         """Test that observations are properly tracked and only changes stored"""

--- a/tests/test_memory/test_lt_memory.py
+++ b/tests/test_memory/test_lt_memory.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -21,16 +21,16 @@ class TestLTMemory:
         assert memory.llm.system_prompt is not None
 
     def test_update_long_term_memory(self, mock_agent, mock_llm):
-        """Test updating long-term memory functionality"""
-        # Mock the LLM's generate method
-        mock_llm.generate.return_value = "Updated long-term memory"
+        """Check that long_term_memory gets the actual text, not the whole response object."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Updated long-term memory"
+        mock_llm.generate.return_value = mock_response
 
         memory = LongTermMemory(agent=mock_agent, llm_model="provider/test_model")
-        # Replace the real LLM with our mock
         memory.llm = mock_llm
         memory.long_term_memory = "Previous memory"
 
-        # Add some content to buffer
         memory.buffer = MemoryEntry(
             agent=mock_agent,
             content={"message": "Test message"},
@@ -39,12 +39,37 @@ class TestLTMemory:
 
         memory._update_long_term_memory()
 
-        # Verify LLM can call with correct prompt structure
         call_args = mock_llm.generate.call_args[0][0]
         assert "new memory entry" in call_args
         assert "Long term memory" in call_args
 
+        assert isinstance(memory.long_term_memory, str)
         assert memory.long_term_memory == "Updated long-term memory"
+
+    def test_long_term_memory_stores_string_not_response_object(
+        self, mock_agent, mock_llm
+    ):
+        """Make sure long_term_memory is always a plain string.
+        Before this fix, it was storing the whole LLM response object instead
+        of just the text — which broke any prompt that used the memory.
+        """
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "This is the summary text"
+        mock_llm.generate.return_value = mock_response
+
+        memory = LongTermMemory(agent=mock_agent, llm_model="provider/test_model")
+        memory.llm = mock_llm
+        memory.buffer = MemoryEntry(
+            agent=mock_agent, content={"observation": "test"}, step=1
+        )
+
+        memory._update_long_term_memory()
+
+        assert isinstance(memory.long_term_memory, str), (
+            "long_term_memory must be a string, not a ModelResponse object"
+        )
+        assert memory.long_term_memory == "This is the summary text"
 
     # process step test
     def test_process_step(self, mock_agent):
@@ -56,15 +81,16 @@ class TestLTMemory:
         memory.add_to_memory("plan", {"content": "Test plan"})
 
         # Process the step
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "mocked summary"
         with (
             patch("rich.console.Console"),
-            patch.object(memory.llm, "generate", return_value="mocked summary"),
+            patch.object(memory.llm, "generate", return_value=mock_response),
         ):
             memory.process_step(pre_step=True)
             assert isinstance(memory.buffer, MemoryEntry)
-            # assert memory.buffer is not None
 
-            # Process post-step
             memory.process_step(pre_step=False)
             assert memory.long_term_memory == "mocked summary"
 
@@ -78,13 +104,12 @@ class TestLTMemory:
 
     @pytest.mark.asyncio
     async def test_aupdate_long_term_memory(self, mock_agent, mock_llm):
-        """
-        The _aupdate_long_term_memory is the async version of the update_long_term_memory, it checks whether the agenerate() method is called
-        and also stores the return value to self.long_term_memory
-
-        The test function ensures that these 2 conditions are checked and verified.
-        """
-        mock_llm.agenerate = AsyncMock(return_value="async summary")
+        """Same as above but for the async version — makes sure it also
+        saves just the text, not the whole response object."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "async summary"
+        mock_llm.agenerate = AsyncMock(return_value=mock_response)
 
         memory = LongTermMemory(agent=mock_agent, llm_model="provider/test_model")
         memory.llm = mock_llm
@@ -92,10 +117,8 @@ class TestLTMemory:
 
         await memory._aupdate_long_term_memory()
 
-        # checks whether agenerate() function was called once
         mock_llm.agenerate.assert_called_once()
-
-        # checks to ensure that the the long term memory is updated correctly with the value we gave through agenerate()
+        assert isinstance(memory.long_term_memory, str)
         assert memory.long_term_memory == "async summary"
 
     @pytest.mark.asyncio
@@ -115,15 +138,16 @@ class TestLTMemory:
         memory.add_to_memory("plan", {"content": "Test plan"})
 
         # Mock async LLM call
-        memory.llm.agenerate = AsyncMock(return_value="mocked async summary")
+        mock_async_response = MagicMock()
+        mock_async_response.choices = [MagicMock()]
+        mock_async_response.choices[0].message.content = "mocked async summary"
+        memory.llm.agenerate = AsyncMock(return_value=mock_async_response)
 
         with patch("rich.console.Console"):
-            # Pre-step assertion is used to check if a new memory entry was created correctly as intended
             await memory.aprocess_step(pre_step=True)
             assert isinstance(memory.buffer, MemoryEntry)
             assert memory.buffer.step is None
 
-            # Post-step assertion is used to check if the previous content was restored
             await memory.aprocess_step(pre_step=False)
             assert memory.long_term_memory == "mocked async summary"
             assert memory.step_content == {}


### PR DESCRIPTION


### Summary

`_update_long_term_memory()` in both `STLTMemory` and `LongTermMemory` stores the raw litellm `ModelResponse` object instead of the actual text content. This silently corrupts the long-term memory — `format_long_term()` ends up dumping full API response JSON into future prompts, wasting tokens and confusing LLM reasoning.

### Bug / Issue

Fixes #102 

`ModuleLLM.generate()` returns a litellm `ModelResponse` object, not a string. But `_update_long_term_memory()` assigns it directly:

\`\`\`python
self.long_term_memory = self.llm.generate(prompt)
\`\`\`

When `format_long_term()` later calls `str(self.long_term_memory)`, the entire raw response object gets serialized into prompts instead of just the summary text.

### Implementation

Extracted `.choices[0].message.content` from the response before storing, which is consistent with how every other `generate()` caller in the codebase handles it (e.g., `CoTReasoning.plan()` at cot.py:113, `ReActReasoning.plan()` at react.py:91).

Files changed:
- `mesa_llm/memory/st_lt_memory.py` — `_update_long_term_memory()` and `_aupdate_long_term_memory()`
- `mesa_llm/memory/lt_memory.py` — `_update_long_term_memory()` and `_aupdate_long_term_memory()`

### Testing

Verified that the fix is consistent with how all other LLM response handling works across the codebase. The change is minimal — splitting one line into two to properly extract the text content.

### Additional Notes

None. This is a straightforward fix with no side effects.