### PR TITLE
remove redundant linter from GA and  update ruff hook in pre-commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,11 +51,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pip-
 
-    - name: Lint with Ruff
-      run: |
-        ruff check .
-        ruff format --check .
-
     - name: Run tests with pytest
       run: |
         pytest tests/ --cov=mesa_llm --cov-report=xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.14"
       - name: Install dependencies
         run: pip install -U pip build wheel setuptools
       - name: Build distributions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
   rev: v0.14.14
   hooks:
     # Run the linter with fix argument.
-    - id: ruff
+    - id: ruff-check
       types_or: [ python, pyi, jupyter ]
       args: [--fix]  # This will enable automatic fixing of lint issues where possible.
     # Run the formatter.
@@ -18,7 +18,7 @@ repos:
   rev: v3.21.2
   hooks:
     - id: pyupgrade
-      args: [--py311-plus]
+      args: [--py312-plus]
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v6.0.0  # Use the ref you want to point at
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ asyncio_default_fixture_loop_scope = "function"
 
 [tool.ruff]
 line-length = 88
-target-version = "py311"
+target-version = "py312"
 lint.select = [
     # "ANN", # annotations TODO
     "B", # bugbear
@@ -117,7 +117,7 @@ extend-exclude = ["docs", "build"]
 convention = "google"
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true


### PR DESCRIPTION
This PR:

- removes redundant ruff check from GH Actions, since it's part of pre-commit
- update ruff hook to be ruff-check in pre-commit
- update python version from 3.11 to 3.12