### PR TITLE
fix: replace deprecated AgentSet indexing for Mesa 4.0 compatibility

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,7 +119,7 @@ def grid_model():
 def basic_agent(basic_model):
     """Create single agent with memory"""
     agents = LLMAgent.create_agents(basic_model, n=1, vision=0, **DEFAULT_AGENT_CONFIG)
-    agent = agents[0]
+    agent = agents.to_list()[0]
     agent.memory = ShortTermMemory(agent=agent, n=5, display=True)
     return agent
 

--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -343,7 +343,7 @@ def _make_agent(model, vision=0, internal_state=None):
         vision=vision,
         internal_state=internal_state or ["test"],
     )
-    agent = agents[0]
+    agent = agents.to_list()[0]
     agent.memory = ShortTermMemory(agent=agent, n=5, display=True)
     return agent
 
@@ -506,7 +506,7 @@ def test_generate_obs_vision_all_agents(monkeypatch):
         a.memory = ShortTermMemory(agent=a, n=5, display=True)
         model.grid.place_agent(a, (idx, idx))
 
-    agent = agents[0]
+    agent = agents.to_list()[0]
     monkeypatch.setattr(agent.memory, "add_to_memory", lambda *a, **kw: None)
     obs = agent.generate_obs()
 
@@ -529,7 +529,7 @@ def test_generate_obs_no_grid_with_vision(monkeypatch):
         vision=5,
         internal_state=["test"],
     )
-    agent = agents[0]
+    agent = agents.to_list()[0]
     agent.unique_id = 1
     agent.memory = ShortTermMemory(agent=agent, n=5, display=True)
     monkeypatch.setattr(agent.memory, "add_to_memory", lambda *a, **kw: None)


### PR DESCRIPTION
## Summary
Fixes `PendingDeprecationWarning: AgentSet.__getitem__ is deprecated 
and will be removed in Mesa 4.0` in existing tests.

## Changes
- `tests/test_llm_agent.py`: Replace `agents[0]` with `agents.to_list()[0]` (3 occurrences)
- `tests/conftest.py`: Replace `agents[0]` with `agents.to_list()[0]` (1 occurrence in `basic_agent` fixture)

## Testing
All 189 tests pass. The 4 `PendingDeprecationWarning`s from `AgentSet.__getitem__` 
are now resolved.

Ref: https://mesa.readthedocs.io/latest/migration_guide.html#AgentSet-sequence-behavior