### PR TITLE
fix: align STLTMemory.get_prompt_ready() return type with Memory ABC

### DIFF
--- a/mesa_llm/memory/st_lt_memory.py
+++ b/mesa_llm/memory/st_lt_memory.py
@@ -193,10 +193,10 @@ class STLTMemory(Memory):
             return "\n".join(lines)
 
     def get_prompt_ready(self) -> str:
-        return [
-            f"Short term memory:\n {self.format_short_term()}",
-            f"Long term memory: \n{self.format_long_term()}",
-        ]
+        return (
+            f"Short term memory:\n {self.format_short_term()}\n\n"
+            f"Long term memory: \n{self.format_long_term()}"
+        )
 
     def get_communication_history(self) -> str:
         """

--- a/mesa_llm/reasoning/react.py
+++ b/mesa_llm/reasoning/react.py
@@ -46,7 +46,7 @@ class ReActReasoning(Reasoning):
         return system_prompt
 
     def get_react_prompt(self, obs: Observation) -> list[str]:
-        prompt_list = self.agent.memory.get_prompt_ready()
+        prompt_list = [self.agent.memory.get_prompt_ready()]
         last_communication = self.agent.memory.get_communication_history()
 
         if last_communication:

--- a/tests/test_memory/test_STLT_memory.py
+++ b/tests/test_memory/test_STLT_memory.py
@@ -175,9 +175,7 @@ class TestSTLTMemory:
         memory = STLTMemory(agent=mock_agent, llm_model="provider/test_model")
 
         memory.short_term_memory.append(
-            MemoryEntry(
-                content={"observation": "Test obs"}, step=1, agent=mock_agent
-            )
+            MemoryEntry(content={"observation": "Test obs"}, step=1, agent=mock_agent)
         )
         memory.long_term_memory = "Long-term summary"
 
@@ -202,4 +200,3 @@ class TestSTLTMemory:
         )
         assert "Short term memory:" in result
         assert "Long term memory:" in result
-

--- a/tests/test_memory/test_STLT_memory.py
+++ b/tests/test_memory/test_STLT_memory.py
@@ -169,3 +169,37 @@ class TestSTLTMemory:
 
         # Verify last observation is tracked
         assert memory.last_observation == obs2
+
+    def test_get_prompt_ready_returns_str(self, mock_agent):
+        """Test that get_prompt_ready returns a str, not a list (issue #116)."""
+        memory = STLTMemory(agent=mock_agent, llm_model="provider/test_model")
+
+        memory.short_term_memory.append(
+            MemoryEntry(
+                content={"observation": "Test obs"}, step=1, agent=mock_agent
+            )
+        )
+        memory.long_term_memory = "Long-term summary"
+
+        result = memory.get_prompt_ready()
+
+        assert isinstance(result, str), (
+            f"get_prompt_ready() must return str, got {type(result).__name__}"
+        )
+        assert "Short term memory:" in result
+        assert "Long term memory:" in result
+        assert "Test obs" in result
+        assert "Long-term summary" in result
+
+    def test_get_prompt_ready_returns_str_when_empty(self, mock_agent):
+        """Test that get_prompt_ready returns str even with empty memory."""
+        memory = STLTMemory(agent=mock_agent, llm_model="provider/test_model")
+
+        result = memory.get_prompt_ready()
+
+        assert isinstance(result, str), (
+            f"get_prompt_ready() must return str, got {type(result).__name__}"
+        )
+        assert "Short term memory:" in result
+        assert "Long term memory:" in result
+

--- a/tests/test_reasoning/test_react.py
+++ b/tests/test_reasoning/test_react.py
@@ -47,7 +47,7 @@ class TestReActReasoning:
         """Test get_react_prompt with observation."""
         mock_agent = Mock()
         mock_agent.memory = Mock()
-        mock_agent.memory.get_prompt_ready.return_value = ["memory1", "memory2"]
+        mock_agent.memory.get_prompt_ready.return_value = "memory1\n\nmemory2"
         mock_agent.memory.get_communication_history.return_value = "communication"
 
         reasoning = ReActReasoning(mock_agent)
@@ -63,7 +63,7 @@ class TestReActReasoning:
         """Test get_react_prompt without observation."""
         mock_agent = Mock()
         mock_agent.memory = Mock()
-        mock_agent.memory.get_prompt_ready.return_value = ["memory1"]
+        mock_agent.memory.get_prompt_ready.return_value = "memory1"
         mock_agent.memory.get_communication_history.return_value = ""
 
         reasoning = ReActReasoning(mock_agent)
@@ -77,7 +77,7 @@ class TestReActReasoning:
         """Test plan method with custom prompt."""
         mock_agent = Mock()
         mock_agent.memory = Mock()
-        mock_agent.memory.get_prompt_ready.return_value = ["memory1"]
+        mock_agent.memory.get_prompt_ready.return_value = "memory1"
         mock_agent.memory.get_communication_history.return_value = ""
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
@@ -108,7 +108,7 @@ class TestReActReasoning:
         mock_agent = Mock()
         mock_agent.step_prompt = "Default step prompt"
         mock_agent.memory = Mock()
-        mock_agent.memory.get_prompt_ready.return_value = ["memory1"]
+        mock_agent.memory.get_prompt_ready.return_value = "memory1"
         mock_agent.memory.get_communication_history.return_value = ""
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
@@ -143,7 +143,7 @@ class TestReActReasoning:
         mock_agent = Mock()
         mock_agent.step_prompt = None
         mock_agent.memory = Mock()
-        mock_agent.memory.get_prompt_ready.return_value = ["memory1"]
+        mock_agent.memory.get_prompt_ready.return_value = "memory1"
         mock_agent.memory.get_communication_history.return_value = ""
 
         reasoning = ReActReasoning(mock_agent)
@@ -159,7 +159,7 @@ class TestReActReasoning:
         mock_agent = Mock()
         mock_agent.step_prompt = "Default step prompt"
         mock_agent.memory = Mock()
-        mock_agent.memory.get_prompt_ready.return_value = ["memory1"]
+        mock_agent.memory.get_prompt_ready.return_value = "memory1"
         mock_agent.memory.get_communication_history.return_value = ""
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.memory.aadd_to_memory = AsyncMock()
@@ -194,7 +194,7 @@ class TestReActReasoning:
         mock_agent = Mock()
         mock_agent.step_prompt = None
         mock_agent.memory = Mock()
-        mock_agent.memory.get_prompt_ready.return_value = ["memory1"]
+        mock_agent.memory.get_prompt_ready.return_value = "memory1"
         mock_agent.memory.get_communication_history.return_value = ""
 
         reasoning = ReActReasoning(mock_agent)


### PR DESCRIPTION
### Summary

`STLTMemory.get_prompt_ready()` returned a `list` instead of `str`, violating the `Memory` ABC contract. Fixed to return a joined string and updated `ReActReasoning` to handle the corrected return type.

### Bug / Issue

Fixes #113

`STLTMemory.get_prompt_ready()` returned a `list[str]` while the `Memory` ABC declares `-> str`. All other backends (`ShortTermMemory`, `LongTermMemory`, `EpisodicMemory`) correctly return `str`. Since `STLTMemory` is the default memory in `LLMAgent`.

### Implementation

**`mesa_llm/memory/st_lt_memory.py`**
- Joined the two list items into a single string with `"\n\n"` separator

**`mesa_llm/reasoning/react.py`**
- `get_react_prompt()` now wraps the `str` result from `get_prompt_ready()` in a list, since it later appends communication history and observation items

**`tests/test_reasoning/test_react.py`**
- Updated 7 mock return values from `list` to `str`

**`tests/test_memory/test_STLT_memory.py`**
- Added 2 regression tests asserting `get_prompt_ready()` returns `str` (with populated and empty memory)

### Testing

All tests pass
<img width="726" height="38" alt="Screenshot 2026-03-01 at 6 51 20 PM" src="https://github.com/user-attachments/assets/0df56d18-dd43-405e-a747-073d96f192d5" />


<img width="598" height="69" alt="Screenshot 2026-03-01 at 6 51 14 PM" src="https://github.com/user-attachments/assets/ea2ae8bd-e78d-466e-b8e1-d29bcb9ad1ee" />



### Additional Notes
