### PR TITLE
fix: : remove duplicate space arg in ContinuousSpace teleport logic(#119)

### DIFF
--- a/mesa_llm/tools/inbuilt_tools.py
+++ b/mesa_llm/tools/inbuilt_tools.py
@@ -81,7 +81,7 @@ def teleport_to_location(
         agent.cell = cell
 
     elif isinstance(agent.model.space, ContinuousSpace):
-        agent.model.space.move_agent(agent.model.space, agent, target_coordinates)
+        agent.model.space.move_agent(agent, target_coordinates)
 
     return f"agent {agent.unique_id} moved to {target_coordinates}."
 

--- a/mesa_llm/tools/inbuilt_tools.py
+++ b/mesa_llm/tools/inbuilt_tools.py
@@ -58,13 +58,13 @@ def move_one_step(agent: "LLMAgent", direction: str) -> str:
 @tool
 def teleport_to_location(
     agent: "LLMAgent",
-    target_coordinates: list[int],
+    target_coordinates: list[int | float],
 ) -> str:
     """
     Instantly moves agents to specific [x, y] coordinates within grid boundaries. Useful for rapid repositioning or spawning mechanics. Validates coordinates are within environment bounds.
 
     Args:
-        target_coordinates: Exactly two integers in the form [x, y] that fall inside the current environment bounds. Example: [3, 7]
+        target_coordinates: Exactly two numeric coordinates in the form [x, y] that fall inside the current environment bounds. Examples: [3, 7] or [3.5, 7.25]
         agent: Provided automatically
 
     Returns:

--- a/tests/test_tools/test_inbuilt_tools.py
+++ b/tests/test_tools/test_inbuilt_tools.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 from mesa.discrete_space import OrthogonalMooreGrid
-from mesa.space import MultiGrid, SingleGrid
+from mesa.space import ContinuousSpace, MultiGrid, SingleGrid
 
 from mesa_llm.tools.inbuilt_tools import (
     move_one_step,
@@ -120,3 +120,34 @@ def test_move_one_step_invalid_direction():
 
     with pytest.raises(ValueError):
         move_one_step(agent, "north east")
+
+
+def test_teleport_to_location_on_continuousspace():
+    model = DummyModel()
+    model.grid = None
+    model.space = ContinuousSpace(x_max=10.0, y_max=10.0, torus=False)
+
+    agent = DummyAgent(unique_id=5, model=model)
+    model.agents.append(agent)
+    model.space.place_agent(agent, (1.0, 1.0))
+
+    out = teleport_to_location(agent, [5.0, 7.0])
+
+    assert agent.pos == (5.0, 7.0)
+    assert out == "agent 5 moved to (5.0, 7.0)."
+
+
+def test_move_one_step_on_continuousspace():
+    """move_one_step delegates to teleport_to_location, verify it works on ContinuousSpace too."""
+    model = DummyModel()
+    model.grid = None
+    model.space = ContinuousSpace(x_max=10.0, y_max=10.0, torus=False)
+
+    agent = DummyAgent(unique_id=6, model=model)
+    model.agents.append(agent)
+    model.space.place_agent(agent, (2.0, 2.0))
+
+    result = move_one_step(agent, "North")
+
+    assert agent.pos == (2.0, 3.0)
+    assert result == "agent 6 moved to (2.0, 3.0)."


### PR DESCRIPTION
### Summary
Fixes #119 

`teleport_to_location` in `inbuilt_tools.py` was calling:

```python
agent.model.space.move_agent(agent.model.space, agent, target_coordinates)
```

In `ContinuousSpace.move_agent(self, agent, pos)` , `self` is already bound when
called as a method. The extra `agent.model.space` argument caused a `TypeError`
every time an LLM agent moved on a `ContinuousSpace`. Since `move_one_step`
delegates to `teleport_to_location`, both tools were broken.
### Bug / Issue
Fixes - #119 

### Implementation
```python
elif isinstance(agent.model.space, ContinuousSpace):
    agent.model.space.move_agent(agent, target_coordinates)
```
### Changes

| File | Change |
|------|--------|
| `mesa_llm/tools/inbuilt_tools.py` | Remove duplicate `agent.model.space` argument|
| `tests/test_tools/test_inbuilt_tools.py` | Add `test_teleport_to_location_on_continuousspace` and `test_move_one_step_on_continuousspace` |

### Before / After

```python
# Before
agent.model.space.move_agent(agent.model.space, agent, target_coordinates)

# After
agent.model.space.move_agent(agent, target_coordinates)
```
### Testing
```
PASSED test_teleport_to_location_on_continuousspace
PASSED test_move_one_step_on_continuousspace
All 7 passed.
```

