### PR TITLE
Respect ignore_agent flag in docstring validation

### DIFF
--- a/mesa_llm/tools/tool_decorator.py
+++ b/mesa_llm/tools/tool_decorator.py
@@ -294,6 +294,7 @@ def _parse_docstring(
     # ---------- validation ---------------------------------------------------------
     sig_params: list[str] = [
         p.name for p in inspect.signature(func).parameters.values()
+        if not (ignore_agent and p.name.lower() == "agent")
     ]
     missing = [p for p in sig_params if p not in param_desc]
     if missing:
@@ -326,7 +327,7 @@ def tool(
 
     def decorator(func: Callable):
         name = func.__name__
-        description, arg_docs, return_docs = _parse_docstring(func)
+        description, arg_docs, return_docs = _parse_docstring(func, ignore_agent=ignore_agent)
 
         sig = inspect.signature(func)
         try:

--- a/mesa_llm/tools/tool_decorator.py
+++ b/mesa_llm/tools/tool_decorator.py
@@ -212,8 +212,11 @@ def _parse_docstring(
 ) -> tuple[str, dict[str, str], str | None]:
     """
     Parse a function's Google-style docstring.
+
     Args:
         func: The function to parse the docstring of.
+        ignore_agent: If True, skip validating docstring entries for any
+            parameter named `agent`. Default is True.
 
     Returns:
         summary: One-line/high-level description that appears before the *Args* section.

--- a/mesa_llm/tools/tool_decorator.py
+++ b/mesa_llm/tools/tool_decorator.py
@@ -293,7 +293,8 @@ def _parse_docstring(
 
     # ---------- validation ---------------------------------------------------------
     sig_params: list[str] = [
-        p.name for p in inspect.signature(func).parameters.values()
+        p.name
+        for p in inspect.signature(func).parameters.values()
         if not (ignore_agent and p.name.lower() == "agent")
     ]
     missing = [p for p in sig_params if p not in param_desc]
@@ -327,7 +328,9 @@ def tool(
 
     def decorator(func: Callable):
         name = func.__name__
-        description, arg_docs, return_docs = _parse_docstring(func, ignore_agent=ignore_agent)
+        description, arg_docs, return_docs = _parse_docstring(
+            func, ignore_agent=ignore_agent
+        )
 
         sig = inspect.signature(func)
         try:

--- a/tests/test_tools/test_tool_decorator.py
+++ b/tests/test_tools/test_tool_decorator.py
@@ -121,3 +121,58 @@ class TestToolDecoractor:
         )
 
         _GLOBAL_TOOL_REGISTRY.clear()
+
+    def test_parse_docstring_ignore_agent_true(self):
+        def tool_func(agent, x: int) -> str:
+            """Short summary.
+
+            Args:
+                x: An integer input.
+
+            Returns:
+                A string.
+            """
+            return str(x)
+
+        summary, param_desc, _ = _parse_docstring(tool_func, ignore_agent=True)
+        assert summary == "Short summary."
+        assert "x" in param_desc
+        assert "agent" not in param_desc
+
+    def test_parse_docstring_ignore_agent_false(self):
+        def tool_func(agent, x: int) -> str:
+            """Short summary.
+
+            Args:
+                x: An integer input.
+
+            Returns:
+                A string.
+            """
+            return str(x)
+
+        with pytest.raises(DocstringParsingError):
+            _parse_docstring(tool_func, ignore_agent=False)
+
+    def test_tool_agent_docstring_not_required(self):
+        _GLOBAL_TOOL_REGISTRY.clear()
+
+        @tool
+        def move(agent, direction: str) -> str:
+            """Move in a direction.
+
+            Args:
+                direction: The direction to move.
+
+            Returns:
+                A result string.
+            """
+            return direction
+
+        assert "move" in _GLOBAL_TOOL_REGISTRY
+        schema = move.__tool_schema__
+        params = schema["function"]["parameters"]
+        assert "agent" not in params["properties"]
+        assert "agent" not in params["required"]
+
+        _GLOBAL_TOOL_REGISTRY.clear()


### PR DESCRIPTION
Fixes #129

Forward ignore_agent into _parse_docstring and apply it when validating docstring arguments.
Adds regression tests for ignore_agent=True and False.