### PR TITLE
fix: add missing obs and ttl params to ReWOOReasoning.plan() and apla…

### DIFF
--- a/mesa_llm/reasoning/cot.py
+++ b/mesa_llm/reasoning/cot.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import TYPE_CHECKING
 
 from mesa_llm.reasoning.reasoning import Observation, Plan, Reasoning
@@ -87,9 +88,9 @@ class CoTReasoning(Reasoning):
 
     def plan(
         self,
-        obs: Observation,
-        ttl: int = 1,
         prompt: str | None = None,
+        obs: Observation | None = None,
+        ttl: int = 1,
         selected_tools: list[str] | None = None,
     ) -> Plan:
         """
@@ -101,6 +102,9 @@ class CoTReasoning(Reasoning):
                 prompt = self.agent.step_prompt
             else:
                 raise ValueError("No prompt provided and agent.step_prompt is None.")
+
+        if obs is None:
+            obs = self.agent.generate_obs()
 
         step = obs.step + 1
         llm = self.agent.llm
@@ -131,7 +135,7 @@ class CoTReasoning(Reasoning):
             tool_choice="required",
         )
         response_message = rsp.choices[0].message
-        cot_plan = Plan(step=step, llm_plan=response_message, ttl=1)
+        cot_plan = Plan(step=step, llm_plan=response_message, ttl=ttl)
 
         self.agent.memory.add_to_memory(type="Plan-Execution", content=str(cot_plan))
 
@@ -139,14 +143,28 @@ class CoTReasoning(Reasoning):
 
     async def aplan(
         self,
-        prompt: str,
-        obs: Observation,
+        prompt: str | None = None,
+        obs: Observation | None = None,
         ttl: int = 1,
         selected_tools: list[str] | None = None,
     ) -> Plan:
         """
         Asynchronous version of plan() method for parallel planning.
         """
+        # If no prompt is provided, use the agent's default step prompt
+        if prompt is None:
+            if self.agent.step_prompt is not None:
+                prompt = self.agent.step_prompt
+            else:
+                raise ValueError("No prompt provided and agent.step_prompt is None.")
+
+        if obs is None:
+            agenerate_obs = getattr(self.agent, "agenerate_obs", None)
+            if agenerate_obs is not None and inspect.iscoroutinefunction(agenerate_obs):
+                obs = await self.agent.agenerate_obs()
+            else:
+                obs = self.agent.generate_obs()
+
         step = obs.step + 1
         llm = self.agent.llm
 
@@ -173,7 +191,7 @@ class CoTReasoning(Reasoning):
             tool_choice="required",
         )
         response_message = rsp.choices[0].message
-        cot_plan = Plan(step=step, llm_plan=response_message, ttl=1)
+        cot_plan = Plan(step=step, llm_plan=response_message, ttl=ttl)
 
         await self.agent.memory.aadd_to_memory(
             type="Plan-Execution", content=str(cot_plan)

--- a/mesa_llm/reasoning/react.py
+++ b/mesa_llm/reasoning/react.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 from typing import TYPE_CHECKING
 
@@ -58,25 +59,29 @@ class ReActReasoning(Reasoning):
 
     def plan(
         self,
-        obs: Observation,
-        ttl: int = 1,
         prompt: str | None = None,
+        obs: Observation | None = None,
+        ttl: int = 1,
         selected_tools: list[str] | None = None,
     ) -> Plan:
         """
         Plan the next (ReAct) action based on the current observation and the agent's memory.
         """
 
+        if obs is None:
+            obs = self.agent.generate_obs()
+
         # ---------------- prepare the prompt ----------------
         self.agent.llm.system_prompt = self.get_react_system_prompt()
         prompt_list = self.get_react_prompt(obs)
 
-        # If no prompt is provided, use the agent's default step prompt
-        if prompt is None:
-            if self.agent.step_prompt is not None:
-                prompt_list.append(self.agent.step_prompt)
-            else:
-                raise ValueError("No prompt provided and agent.step_prompt is None.")
+        # Add user prompt (explicit prompt takes precedence over default step prompt)
+        if prompt is not None:
+            prompt_list.append(prompt)
+        elif self.agent.step_prompt is not None:
+            prompt_list.append(self.agent.step_prompt)
+        else:
+            raise ValueError("No prompt provided and agent.step_prompt is None.")
 
         selected_tools_schema = self.agent.tool_manager.get_all_tools_schema(
             selected_tools
@@ -96,32 +101,41 @@ class ReActReasoning(Reasoning):
 
         # ---------------- execute the plan ----------------
         react_plan = self.execute_tool_call(
-            formatted_response["action"], selected_tools
+            formatted_response["action"],
+            selected_tools=selected_tools,
+            ttl=ttl,
         )
 
         return react_plan
 
     async def aplan(
         self,
-        obs: Observation,
-        ttl: int = 1,
         prompt: str | None = None,
+        obs: Observation | None = None,
+        ttl: int = 1,
         selected_tools: list[str] | None = None,
     ) -> Plan:
         """
         Asynchronous version of plan() method for parallel planning.
         """
+        if obs is None:
+            agenerate_obs = getattr(self.agent, "agenerate_obs", None)
+            if agenerate_obs is not None and inspect.iscoroutinefunction(agenerate_obs):
+                obs = await self.agent.agenerate_obs()
+            else:
+                obs = self.agent.generate_obs()
 
         # ---------------- prepare the prompt ----------------
         self.agent.llm.system_prompt = self.get_react_system_prompt()
         prompt_list = self.get_react_prompt(obs)
 
-        # If no prompt is provided, use the agent's default step prompt
-        if prompt is None:
-            if self.agent.step_prompt is not None:
-                prompt_list.append(self.agent.step_prompt)
-            else:
-                raise ValueError("No prompt provided and agent.step_prompt is None.")
+        # Add user prompt (explicit prompt takes precedence over default step prompt)
+        if prompt is not None:
+            prompt_list.append(prompt)
+        elif self.agent.step_prompt is not None:
+            prompt_list.append(self.agent.step_prompt)
+        else:
+            raise ValueError("No prompt provided and agent.step_prompt is None.")
 
         selected_tools_schema = self.agent.tool_manager.get_all_tools_schema(
             selected_tools
@@ -142,7 +156,9 @@ class ReActReasoning(Reasoning):
 
         # ---------------- execute the plan ----------------
         react_plan = await self.aexecute_tool_call(
-            formatted_response["action"], selected_tools
+            formatted_response["action"],
+            selected_tools=selected_tools,
+            ttl=ttl,
         )
 
         return react_plan

--- a/mesa_llm/reasoning/reasoning.py
+++ b/mesa_llm/reasoning/reasoning.py
@@ -79,7 +79,7 @@ class Reasoning(ABC):
     @abstractmethod
     def plan(
         self,
-        prompt: str,
+        prompt: str | None = None,
         obs: Observation | None = None,
         ttl: int = 1,
         selected_tools: list[str] | None = None,
@@ -88,7 +88,7 @@ class Reasoning(ABC):
 
     async def aplan(
         self,
-        prompt: str,
+        prompt: str | None = None,
         obs: Observation | None = None,
         ttl: int = 1,
         selected_tools: list[str] | None = None,
@@ -97,10 +97,18 @@ class Reasoning(ABC):
         Asynchronous version of plan() method for parallel planning.
         Default implementation calls the synchronous plan() method.
         """
-        return self.plan(prompt, obs, ttl, selected_tools)
+        return self.plan(
+            prompt=prompt,
+            obs=obs,
+            ttl=ttl,
+            selected_tools=selected_tools,
+        )
 
     def execute_tool_call(
-        self, chaining_message, selected_tools: list[str] | None = None
+        self,
+        chaining_message,
+        selected_tools: list[str] | None = None,
+        ttl: int = 1,
     ):
         system_prompt = "You are an executor that executes the plan given to you in the prompt through tool calls."
         self.agent.llm.system_prompt = system_prompt
@@ -112,12 +120,15 @@ class Reasoning(ABC):
             tool_choice="required",
         )
         response_message = rsp.choices[0].message
-        plan = Plan(step=self.agent.model.steps, llm_plan=response_message, ttl=1)
+        plan = Plan(step=self.agent.model.steps, llm_plan=response_message, ttl=ttl)
 
         return plan
 
     async def aexecute_tool_call(
-        self, chaining_message, selected_tools: list[str] | None = None
+        self,
+        chaining_message,
+        selected_tools: list[str] | None = None,
+        ttl: int = 1,
     ):
         """
         Asynchronous version of execute_tool_call() method.
@@ -132,6 +143,6 @@ class Reasoning(ABC):
             tool_choice="required",
         )
         response_message = rsp.choices[0].message
-        plan = Plan(step=self.agent.model.steps, llm_plan=response_message, ttl=1)
+        plan = Plan(step=self.agent.model.steps, llm_plan=response_message, ttl=ttl)
 
         return plan

--- a/mesa_llm/reasoning/rewoo.py
+++ b/mesa_llm/reasoning/rewoo.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import TYPE_CHECKING
 
 from mesa_llm.reasoning.reasoning import (
@@ -68,7 +69,7 @@ class ReWOOReasoning(Reasoning):
         ---
 
         # Current Observation
-        {self.current_obs}
+        {obs}
 
         ---
 
@@ -124,9 +125,12 @@ class ReWOOReasoning(Reasoning):
             tool_call = [self.current_plan.tool_calls[index_of_tool]]
             current_plan = self.current_plan
             current_plan.tool_calls = tool_call
-            return Plan(llm_plan=current_plan, step=self.current_obs.step, ttl=1)
+            return Plan(llm_plan=current_plan, step=self.current_obs.step, ttl=ttl)
 
-        self.current_obs = self.agent.generate_obs()
+        if obs is None:
+            self.current_obs = self.agent.generate_obs()
+        else:
+            self.current_obs = obs
         llm = self.agent.llm
         system_prompt = self.get_rewoo_system_prompt(self.current_obs)
 
@@ -142,7 +146,9 @@ class ReWOOReasoning(Reasoning):
         )
 
         rewoo_plan = self.execute_tool_call(
-            rsp.choices[0].message.content, selected_tools
+            rsp.choices[0].message.content,
+            selected_tools=selected_tools,
+            ttl=ttl,
         )
         # Count the number of tool calls in the response and set remaining_tool_calls
         if hasattr(rewoo_plan.llm_plan, "tool_calls"):
@@ -155,7 +161,7 @@ class ReWOOReasoning(Reasoning):
 
     async def aplan(
         self,
-        prompt: str,
+        prompt: str | None = None,
         obs: Observation | None = None,
         ttl: int = 1,
         selected_tools: list[str] | None = None,
@@ -163,6 +169,12 @@ class ReWOOReasoning(Reasoning):
         """
         Asynchronous version of plan() method for parallel planning.
         """
+        # If no prompt is provided, use the agent's default step prompt
+        if prompt is None:
+            if self.agent.step_prompt is not None:
+                prompt = self.agent.step_prompt
+            else:
+                raise ValueError("No prompt provided and agent.step_prompt is None.")
 
         # If we have remaining tool calls, skip observation and plan generation
         if self.remaining_tool_calls > 0:
@@ -173,9 +185,16 @@ class ReWOOReasoning(Reasoning):
             tool_call = [self.current_plan.tool_calls[index_of_tool]]
             current_plan = self.current_plan
             current_plan.tool_calls = tool_call
-            return Plan(llm_plan=current_plan, step=self.current_obs.step, ttl=1)
+            return Plan(llm_plan=current_plan, step=self.current_obs.step, ttl=ttl)
 
-        self.current_obs = self.agent.generate_obs()
+        if obs is None:
+            agenerate_obs = getattr(self.agent, "agenerate_obs", None)
+            if agenerate_obs is not None and inspect.iscoroutinefunction(agenerate_obs):
+                self.current_obs = await self.agent.agenerate_obs()
+            else:
+                self.current_obs = self.agent.generate_obs()
+        else:
+            self.current_obs = obs
         llm = self.agent.llm
         system_prompt = self.get_rewoo_system_prompt(self.current_obs)
 
@@ -191,7 +210,9 @@ class ReWOOReasoning(Reasoning):
         )
 
         rewoo_plan = await self.aexecute_tool_call(
-            rsp.choices[0].message.content, selected_tools
+            rsp.choices[0].message.content,
+            selected_tools=selected_tools,
+            ttl=ttl,
         )
         # Count the number of tool calls in the response and set remaining_tool_calls
         if hasattr(rewoo_plan.llm_plan, "tool_calls"):

--- a/mesa_llm/reasoning/rewoo.py
+++ b/mesa_llm/reasoning/rewoo.py
@@ -102,6 +102,7 @@ class ReWOOReasoning(Reasoning):
         self,
         prompt: str | None = None,
         obs: Observation | None = None,
+        ttl: int = 1,
         selected_tools: list[str] | None = None,
     ) -> Plan:
         """
@@ -152,7 +153,13 @@ class ReWOOReasoning(Reasoning):
 
         return rewoo_plan
 
-    async def aplan(self, prompt: str, selected_tools: list[str] | None = None) -> Plan:
+    async def aplan(
+        self,
+        prompt: str,
+        obs: Observation | None = None,
+        ttl: int = 1,
+        selected_tools: list[str] | None = None,
+    ) -> Plan:
         """
         Asynchronous version of plan() method for parallel planning.
         """

--- a/mesa_llm/reasoning/rewoo.py
+++ b/mesa_llm/reasoning/rewoo.py
@@ -109,13 +109,6 @@ class ReWOOReasoning(Reasoning):
         """
         Plan the next (ReWOO) action based on the current observation and the agent's memory.
         """
-        # If no prompt is provided, use the agent's default step prompt
-        if prompt is None:
-            if self.agent.step_prompt is not None:
-                prompt = self.agent.step_prompt
-            else:
-                raise ValueError("No prompt provided and agent.step_prompt is None.")
-
         # If we have remaining tool calls, skip observation and plan generation
         if self.remaining_tool_calls > 0:
             index_of_tool = (
@@ -126,6 +119,13 @@ class ReWOOReasoning(Reasoning):
             current_plan = self.current_plan
             current_plan.tool_calls = tool_call
             return Plan(llm_plan=current_plan, step=self.current_obs.step, ttl=ttl)
+
+        # If no prompt is provided, use the agent's default step prompt
+        if prompt is None:
+            if self.agent.step_prompt is not None:
+                prompt = self.agent.step_prompt
+            else:
+                raise ValueError("No prompt provided and agent.step_prompt is None.")
 
         if obs is None:
             self.current_obs = self.agent.generate_obs()
@@ -169,13 +169,6 @@ class ReWOOReasoning(Reasoning):
         """
         Asynchronous version of plan() method for parallel planning.
         """
-        # If no prompt is provided, use the agent's default step prompt
-        if prompt is None:
-            if self.agent.step_prompt is not None:
-                prompt = self.agent.step_prompt
-            else:
-                raise ValueError("No prompt provided and agent.step_prompt is None.")
-
         # If we have remaining tool calls, skip observation and plan generation
         if self.remaining_tool_calls > 0:
             index_of_tool = (
@@ -186,6 +179,13 @@ class ReWOOReasoning(Reasoning):
             current_plan = self.current_plan
             current_plan.tool_calls = tool_call
             return Plan(llm_plan=current_plan, step=self.current_obs.step, ttl=ttl)
+
+        # If no prompt is provided, use the agent's default step prompt
+        if prompt is None:
+            if self.agent.step_prompt is not None:
+                prompt = self.agent.step_prompt
+            else:
+                raise ValueError("No prompt provided and agent.step_prompt is None.")
 
         if obs is None:
             agenerate_obs = getattr(self.agent, "agenerate_obs", None)

--- a/tests/test_reasoning/test_cot.py
+++ b/tests/test_reasoning/test_cot.py
@@ -84,12 +84,13 @@ class TestCoTReasoning:
         # Create an observation (step 0 -> plan.step should be 1)
         obs = Observation(step=0, self_state={}, local_state={})
 
-        plan = agent.reasoning.plan(obs)
+        plan = agent.reasoning.plan(obs=obs)
 
         # Assertions
         assert isinstance(plan, Plan)
         assert plan.step == 1
         assert plan.llm_plan.content == "mock execution"
+        assert plan.ttl == 1
         # and our memory.add_to_memory should at least have been called once with type="observation"
         mock_memory.add_to_memory.assert_any_call(
             type="Observation",
@@ -126,9 +127,10 @@ class TestCoTReasoning:
 
         obs = Observation(step=1, self_state={}, local_state={})
         selected_tools = ["tool1", "tool2"]
-        result = reasoning.plan(obs=obs, selected_tools=selected_tools)
+        result = reasoning.plan(obs=obs, ttl=3, selected_tools=selected_tools)
 
         assert isinstance(result, Plan)
+        assert result.ttl == 3
         # Check that tool schema was called with selected tools
         assert mock_agent.tool_manager.get_all_tools_schema.call_count == 2
 
@@ -179,8 +181,9 @@ class TestCoTReasoning:
 
         obs = Observation(step=1, self_state={}, local_state={})
 
-        result = asyncio.run(reasoning.aplan(prompt="Async prompt", obs=obs))
+        result = asyncio.run(reasoning.aplan(prompt="Async prompt", obs=obs, ttl=4))
 
         assert isinstance(result, Plan)
         assert result.step == 2
+        assert result.ttl == 4
         assert mock_agent.llm.agenerate.call_count == 2

--- a/tests/test_reasoning/test_react.py
+++ b/tests/test_reasoning/test_react.py
@@ -101,7 +101,11 @@ class TestReActReasoning:
         result = reasoning.plan(obs=obs, prompt="Custom prompt")
 
         assert result == mock_plan
-        reasoning.execute_tool_call.assert_called_once_with("custom_action", None)
+        reasoning.execute_tool_call.assert_called_once_with(
+            "custom_action",
+            selected_tools=None,
+            ttl=1,
+        )
 
     def test_plan_with_selected_tools(self):
         """Test plan method with selected tools."""
@@ -130,12 +134,14 @@ class TestReActReasoning:
 
         obs = Observation(step=1, self_state={}, local_state={})
         selected_tools = ["tool1", "tool2"]
-        result = reasoning.plan(obs=obs, selected_tools=selected_tools)
+        result = reasoning.plan(obs=obs, ttl=3, selected_tools=selected_tools)
 
         assert result == mock_plan
         mock_agent.tool_manager.get_all_tools_schema.assert_called_with(selected_tools)
         reasoning.execute_tool_call.assert_called_once_with(
-            "test_action", selected_tools
+            "test_action",
+            selected_tools=selected_tools,
+            ttl=3,
         )
 
     def test_plan_no_prompt_error(self):
@@ -183,11 +189,15 @@ class TestReActReasoning:
         obs = Observation(step=1, self_state={}, local_state={})
 
         # Test async execution
-        result = asyncio.run(reasoning.aplan(obs=obs))
+        result = asyncio.run(reasoning.aplan(obs=obs, ttl=4))
 
         assert result == mock_plan
         mock_agent.llm.agenerate.assert_called_once()
-        reasoning.aexecute_tool_call.assert_called_once_with("async_action", None)
+        reasoning.aexecute_tool_call.assert_called_once_with(
+            "async_action",
+            selected_tools=None,
+            ttl=4,
+        )
 
     def test_aplan_no_prompt_error(self):
         """Test aplan method raises error when no prompt is provided."""

--- a/tests/test_reasoning/test_reasoning.py
+++ b/tests/test_reasoning/test_reasoning.py
@@ -62,7 +62,7 @@ class TestReasoningBase:
 
         # 2. Instantiate a concrete implementation of Reasoning to test the base method
         class ConcreteReasoning(Reasoning):
-            def plan(self, prompt, obs=None, ttl=1, selected_tools=None):
+            def plan(self, prompt=None, obs=None, ttl=1, selected_tools=None):
                 pass  # Not needed for this test
 
         reasoning = ConcreteReasoning(agent=mock_agent)
@@ -88,3 +88,24 @@ class TestReasoningBase:
         assert isinstance(result_plan, Plan)
         assert result_plan.step == 5
         assert result_plan.llm_plan == "Final LLM message"
+        assert result_plan.ttl == 1
+
+    def test_execute_tool_call_propagates_ttl(self):
+        """Test that execute_tool_call propagates caller-provided TTL."""
+        mock_agent = Mock()
+        mock_agent.model.steps = 5
+        mock_llm_response = Mock()
+        mock_llm_response.choices = [Mock()]
+        mock_llm_response.choices[0].message = "Final LLM message"
+        mock_agent.llm.generate.return_value = mock_llm_response
+        mock_agent.tool_manager.get_all_tools_schema.return_value = []
+
+        class ConcreteReasoning(Reasoning):
+            def plan(self, prompt=None, obs=None, ttl=1, selected_tools=None):
+                pass
+
+        reasoning = ConcreteReasoning(agent=mock_agent)
+        result_plan = reasoning.execute_tool_call("Execute the plan.", ttl=7)
+
+        assert isinstance(result_plan, Plan)
+        assert result_plan.ttl == 7

--- a/tests/test_reasoning/test_rewoo.py
+++ b/tests/test_reasoning/test_rewoo.py
@@ -63,9 +63,10 @@ class TestReWOOReasoning:
         ]  # 3 tool calls
         reasoning.current_obs = Observation(step=1, self_state={}, local_state={})
 
-        result = reasoning.plan()
+        result = reasoning.plan(ttl=5)
 
         assert isinstance(result, Plan)
+        assert result.ttl == 5
         assert result.llm_plan.tool_calls == [mock_tool_2]  # Should get index 1 (3-2)
         assert reasoning.remaining_tool_calls == 1
         mock_agent.generate_obs.assert_not_called()
@@ -101,17 +102,28 @@ class TestReWOOReasoning:
 
         mock_agent.llm.generate.side_effect = [mock_plan_response, mock_exec_response]
 
-        reasoning = ReWOOReasoning(mock_agent)
-        reasoning.execute_tool_call = Mock(
-            return_value=Plan(step=1, llm_plan=mock_exec_response.choices[0].message)
-        )
+        def execute_with_ttl(*args, **kwargs):
+            return Plan(
+                step=1,
+                llm_plan=mock_exec_response.choices[0].message,
+                ttl=kwargs.get("ttl", 1),
+            )
 
-        result = reasoning.plan()
+        reasoning = ReWOOReasoning(mock_agent)
+        reasoning.execute_tool_call = Mock(side_effect=execute_with_ttl)
+
+        result = reasoning.plan(ttl=4)
 
         assert isinstance(result, Plan)
+        assert result.ttl == 4
         assert reasoning.remaining_tool_calls == 2
         assert reasoning.current_plan == mock_exec_response.choices[0].message
         assert reasoning.current_obs is not None
+        reasoning.execute_tool_call.assert_called_once_with(
+            "Test plan content",
+            selected_tools=None,
+            ttl=4,
+        )
         mock_agent.generate_obs.assert_called_once()
 
     def test_plan_with_custom_prompt(self):
@@ -261,9 +273,10 @@ class TestReWOOReasoning:
         reasoning.current_plan.tool_calls = [mock_tool_1, mock_tool_2]  # 2 tool calls
         reasoning.current_obs = Observation(step=1, self_state={}, local_state={})
 
-        result = asyncio.run(reasoning.aplan("test prompt"))
+        result = asyncio.run(reasoning.aplan("test prompt", ttl=6))
 
         assert isinstance(result, Plan)
+        assert result.ttl == 6
         assert result.llm_plan.tool_calls == [mock_tool_2]  # Should get index 1 (2-1)
         assert reasoning.remaining_tool_calls == 0
         mock_agent.generate_obs.assert_not_called()
@@ -301,18 +314,112 @@ class TestReWOOReasoning:
             side_effect=[mock_plan_response, mock_exec_response]
         )
 
-        reasoning = ReWOOReasoning(mock_agent)
-        reasoning.aexecute_tool_call = AsyncMock(
-            return_value=Plan(step=1, llm_plan=mock_exec_response.choices[0].message)
-        )
+        async def aexecute_with_ttl(*args, **kwargs):
+            return Plan(
+                step=1,
+                llm_plan=mock_exec_response.choices[0].message,
+                ttl=kwargs.get("ttl", 1),
+            )
 
-        result = asyncio.run(reasoning.aplan("test prompt"))
+        reasoning = ReWOOReasoning(mock_agent)
+        reasoning.aexecute_tool_call = AsyncMock(side_effect=aexecute_with_ttl)
+
+        result = asyncio.run(reasoning.aplan("test prompt", ttl=7))
 
         assert isinstance(result, Plan)
+        assert result.ttl == 7
         assert reasoning.remaining_tool_calls == 3
         assert reasoning.current_plan == mock_exec_response.choices[0].message
         assert reasoning.current_obs is not None
+        reasoning.aexecute_tool_call.assert_called_once_with(
+            "Async plan content",
+            selected_tools=None,
+            ttl=7,
+        )
         mock_agent.generate_obs.assert_called_once()
+
+    def test_plan_uses_provided_obs_without_regeneration(self):
+        """Fresh planning should use provided obs and skip generate_obs()."""
+        mock_agent = Mock()
+        mock_agent.step_prompt = "Default step prompt"
+        mock_agent.generate_obs = Mock()
+        mock_agent.memory = Mock()
+        mock_agent.memory.format_long_term.return_value = "Long term memory"
+        mock_agent.memory.format_short_term.return_value = "Short term memory"
+        mock_agent.memory.add_to_memory = Mock()
+        mock_agent.llm = Mock()
+        mock_agent.tool_manager = Mock()
+        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+
+        mock_plan_response = Mock()
+        mock_plan_response.choices = [Mock()]
+        mock_plan_response.choices[0].message.content = "Test plan content"
+        mock_exec_response = Mock()
+        mock_exec_response.choices = [Mock()]
+        mock_exec_response.choices[0].message = Mock()
+        mock_exec_response.choices[0].message.tool_calls = [Mock()]
+        mock_agent.llm.generate.side_effect = [mock_plan_response, mock_exec_response]
+
+        def execute_with_ttl(*args, **kwargs):
+            return Plan(
+                step=1,
+                llm_plan=mock_exec_response.choices[0].message,
+                ttl=kwargs.get("ttl", 1),
+            )
+
+        provided_obs = Observation(step=5, self_state={}, local_state={})
+        reasoning = ReWOOReasoning(mock_agent)
+        reasoning.execute_tool_call = Mock(side_effect=execute_with_ttl)
+
+        result = reasoning.plan(obs=provided_obs, ttl=2)
+
+        assert isinstance(result, Plan)
+        assert result.ttl == 2
+        assert reasoning.current_obs is provided_obs
+        mock_agent.generate_obs.assert_not_called()
+
+    def test_aplan_uses_provided_obs_without_regeneration(self):
+        """Async fresh planning should use provided obs and skip obs generation."""
+        mock_agent = Mock()
+        mock_agent.generate_obs = Mock()
+        mock_agent.agenerate_obs = AsyncMock()
+        mock_agent.memory = Mock()
+        mock_agent.memory.format_long_term.return_value = "Long term memory"
+        mock_agent.memory.format_short_term.return_value = "Short term memory"
+        mock_agent.memory.add_to_memory = Mock()
+        mock_agent.llm = Mock()
+        mock_agent.tool_manager = Mock()
+        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+
+        mock_plan_response = Mock()
+        mock_plan_response.choices = [Mock()]
+        mock_plan_response.choices[0].message.content = "Async plan content"
+        mock_exec_response = Mock()
+        mock_exec_response.choices = [Mock()]
+        mock_exec_response.choices[0].message = Mock()
+        mock_exec_response.choices[0].message.tool_calls = [Mock()]
+        mock_agent.llm.agenerate = AsyncMock(
+            side_effect=[mock_plan_response, mock_exec_response]
+        )
+
+        async def aexecute_with_ttl(*args, **kwargs):
+            return Plan(
+                step=1,
+                llm_plan=mock_exec_response.choices[0].message,
+                ttl=kwargs.get("ttl", 1),
+            )
+
+        provided_obs = Observation(step=6, self_state={}, local_state={})
+        reasoning = ReWOOReasoning(mock_agent)
+        reasoning.aexecute_tool_call = AsyncMock(side_effect=aexecute_with_ttl)
+
+        result = asyncio.run(reasoning.aplan("test prompt", obs=provided_obs, ttl=3))
+
+        assert isinstance(result, Plan)
+        assert result.ttl == 3
+        assert reasoning.current_obs is provided_obs
+        mock_agent.generate_obs.assert_not_called()
+        mock_agent.agenerate_obs.assert_not_called()
 
     def test_aplan_with_selected_tools(self):
         """Test aplan method with selected tools."""
@@ -471,6 +578,7 @@ class TestReWOOSignatureConsistency:
 
         result = reasoning.plan(ttl=3)
         assert isinstance(result, Plan)
+        assert result.ttl == 3
 
     def test_aplan_accepts_obs_kwarg(self):
         """aplan() must accept obs= keyword without raising TypeError."""
@@ -504,3 +612,4 @@ class TestReWOOSignatureConsistency:
 
         result = asyncio.run(reasoning.aplan("test prompt", ttl=5))
         assert isinstance(result, Plan)
+        assert result.ttl == 5

--- a/tests/test_reasoning/test_rewoo.py
+++ b/tests/test_reasoning/test_rewoo.py
@@ -439,3 +439,68 @@ class TestReWOOReasoning:
         result3 = reasoning.plan()
         assert reasoning.remaining_tool_calls == 0
         assert result3.llm_plan.tool_calls == [mock_tool_3]  # index 2 (3-1=2)
+
+
+class TestReWOOSignatureConsistency:
+    def test_plan_accepts_obs_kwarg(self):
+        """plan() must accept obs= keyword without raising TypeError."""
+        mock_agent = Mock()
+        mock_agent.generate_obs.return_value = Observation(
+            step=1, self_state={}, local_state={}
+        )
+        reasoning = ReWOOReasoning(mock_agent)
+        reasoning.remaining_tool_calls = 1
+        reasoning.current_plan = Mock()
+        reasoning.current_plan.tool_calls = [Mock()]
+        reasoning.current_obs = Observation(step=1, self_state={}, local_state={})
+
+        result = reasoning.plan(obs=Observation(step=5, self_state={}, local_state={}))
+        assert isinstance(result, Plan)
+
+    def test_plan_accepts_ttl_kwarg(self):
+        """plan() must accept ttl= keyword without raising TypeError."""
+        mock_agent = Mock()
+        mock_agent.generate_obs.return_value = Observation(
+            step=1, self_state={}, local_state={}
+        )
+        reasoning = ReWOOReasoning(mock_agent)
+        reasoning.remaining_tool_calls = 1
+        reasoning.current_plan = Mock()
+        reasoning.current_plan.tool_calls = [Mock()]
+        reasoning.current_obs = Observation(step=1, self_state={}, local_state={})
+
+        result = reasoning.plan(ttl=3)
+        assert isinstance(result, Plan)
+
+    def test_aplan_accepts_obs_kwarg(self):
+        """aplan() must accept obs= keyword without raising TypeError."""
+        mock_agent = Mock()
+        mock_agent.generate_obs = Mock()
+
+        reasoning = ReWOOReasoning(mock_agent)
+        reasoning.remaining_tool_calls = 1
+        reasoning.current_plan = Mock()
+        reasoning.current_plan.tool_calls = [Mock()]
+        reasoning.current_obs = Observation(step=1, self_state={}, local_state={})
+
+        result = asyncio.run(
+            reasoning.aplan(
+                "test prompt",
+                obs=Observation(step=5, self_state={}, local_state={}),
+            )
+        )
+        assert isinstance(result, Plan)
+
+    def test_aplan_accepts_ttl_kwarg(self):
+        """aplan() must accept ttl= keyword without raising TypeError."""
+        mock_agent = Mock()
+        mock_agent.generate_obs = Mock()
+
+        reasoning = ReWOOReasoning(mock_agent)
+        reasoning.remaining_tool_calls = 1
+        reasoning.current_plan = Mock()
+        reasoning.current_plan.tool_calls = [Mock()]
+        reasoning.current_obs = Observation(step=1, self_state={}, local_state={})
+
+        result = asyncio.run(reasoning.aplan("test prompt", ttl=5))
+        assert isinstance(result, Plan)

--- a/tests/test_reasoning/test_rewoo.py
+++ b/tests/test_reasoning/test_rewoo.py
@@ -47,6 +47,7 @@ class TestReWOOReasoning:
         """Test plan method when there are remaining tool calls."""
         mock_agent = Mock()
         mock_agent.generate_obs = Mock()
+        mock_agent.step_prompt = None
 
         reasoning = ReWOOReasoning(mock_agent)
         reasoning.remaining_tool_calls = 2
@@ -262,6 +263,7 @@ class TestReWOOReasoning:
         """Test aplan method when there are remaining tool calls."""
         mock_agent = Mock()
         mock_agent.generate_obs = Mock()
+        mock_agent.step_prompt = None
 
         reasoning = ReWOOReasoning(mock_agent)
         reasoning.remaining_tool_calls = 1
@@ -273,7 +275,7 @@ class TestReWOOReasoning:
         reasoning.current_plan.tool_calls = [mock_tool_1, mock_tool_2]  # 2 tool calls
         reasoning.current_obs = Observation(step=1, self_state={}, local_state={})
 
-        result = asyncio.run(reasoning.aplan("test prompt", ttl=6))
+        result = asyncio.run(reasoning.aplan(ttl=6))
 
         assert isinstance(result, Plan)
         assert result.ttl == 6
@@ -508,6 +510,7 @@ class TestReWOOReasoning:
         """Test that remaining_tool_calls is properly decremented."""
         mock_agent = Mock()
         mock_agent.generate_obs = Mock()
+        mock_agent.step_prompt = None
 
         reasoning = ReWOOReasoning(mock_agent)
 
@@ -552,6 +555,7 @@ class TestReWOOSignatureConsistency:
     def test_plan_accepts_obs_kwarg(self):
         """plan() must accept obs= keyword without raising TypeError."""
         mock_agent = Mock()
+        mock_agent.step_prompt = None
         mock_agent.generate_obs.return_value = Observation(
             step=1, self_state={}, local_state={}
         )
@@ -567,6 +571,7 @@ class TestReWOOSignatureConsistency:
     def test_plan_accepts_ttl_kwarg(self):
         """plan() must accept ttl= keyword without raising TypeError."""
         mock_agent = Mock()
+        mock_agent.step_prompt = None
         mock_agent.generate_obs.return_value = Observation(
             step=1, self_state={}, local_state={}
         )
@@ -584,6 +589,7 @@ class TestReWOOSignatureConsistency:
         """aplan() must accept obs= keyword without raising TypeError."""
         mock_agent = Mock()
         mock_agent.generate_obs = Mock()
+        mock_agent.step_prompt = None
 
         reasoning = ReWOOReasoning(mock_agent)
         reasoning.remaining_tool_calls = 1
@@ -592,10 +598,7 @@ class TestReWOOSignatureConsistency:
         reasoning.current_obs = Observation(step=1, self_state={}, local_state={})
 
         result = asyncio.run(
-            reasoning.aplan(
-                "test prompt",
-                obs=Observation(step=5, self_state={}, local_state={}),
-            )
+            reasoning.aplan(obs=Observation(step=5, self_state={}, local_state={}))
         )
         assert isinstance(result, Plan)
 
@@ -603,6 +606,7 @@ class TestReWOOSignatureConsistency:
         """aplan() must accept ttl= keyword without raising TypeError."""
         mock_agent = Mock()
         mock_agent.generate_obs = Mock()
+        mock_agent.step_prompt = None
 
         reasoning = ReWOOReasoning(mock_agent)
         reasoning.remaining_tool_calls = 1
@@ -610,6 +614,6 @@ class TestReWOOSignatureConsistency:
         reasoning.current_plan.tool_calls = [Mock()]
         reasoning.current_obs = Observation(step=1, self_state={}, local_state={})
 
-        result = asyncio.run(reasoning.aplan("test prompt", ttl=5))
+        result = asyncio.run(reasoning.aplan(ttl=5))
         assert isinstance(result, Plan)
         assert result.ttl == 5


### PR DESCRIPTION
### Summary
Fixes #125 

`ReWOOReasoning.aplan()` was missing both `obs` and `ttl` parameters and `ReWOOReasoning.plan()` was missing `ttl`.

The base class `Reasoning` defines the contract:
```python
async def aplan(self, prompt, obs=None, ttl=1, selected_tools=None) -> Plan
```

`CoTReasoning` and `ReActReasoning` both implement this correctly.
`ReWOOReasoning` was the only subclass that didn't which was causing a TypeError
whenever a caller passed `obs=` or `ttl=`.

Notably, the `ReWOOReasoning` docstring already documented the correct signature but  the implementation was missed it.

### Bug / Issue
Fixes #125 

### Implementation
```python
# Before
async def aplan(self, prompt: str, selected_tools=None) -> Plan

# After
async def aplan(self, prompt: str, obs=None, ttl: int = 1, selected_tools=None) -> Plan
```
### Testing

```
All 17 passed  (13 existing + 4 new regression tests)
```
