### PR TITLE
Fix/Add Boundary Check in move_one_step to Prevent Cryptic Grid Errors

### DIFF
--- a/mesa_llm/tools/inbuilt_tools.py
+++ b/mesa_llm/tools/inbuilt_tools.py
@@ -82,33 +82,72 @@ def move_one_step(agent: "LLMAgent", direction: str) -> str:
 
     grid = getattr(agent.model, "grid", None)
     if isinstance(grid, OrthogonalMooreGrid | OrthogonalVonNeumannGrid):
-        dx, dy = direction_map_row_col[direction]
-    else:
+        row, col = _get_agent_position(agent)
+        drow, dcol = direction_map_row_col[direction]
+        new_pos = (row + drow, col + dcol)
+
+        if grid.torus:
+            dimensions = grid.dimensions
+            if len(dimensions) == len(new_pos):
+                new_pos = tuple(coord % dim for coord, dim in zip(new_pos, dimensions))
+        elif new_pos not in grid._cells:
+            return (
+                f"Agent {agent.unique_id} is at the boundary and cannot move "
+                f"{direction}. Try a different direction."
+            )
+
+        target_cell = grid._cells.get(new_pos)
+        if target_cell is None:
+            return (
+                f"Agent {agent.unique_id} is at the boundary and cannot move "
+                f"{direction}. Try a different direction."
+            )
+
+        if target_cell.is_full:
+            return (
+                f"Agent {agent.unique_id} cannot move {direction} because "
+                "the target cell is full."
+            )
+
+        target_coordinates = tuple(target_cell.coordinate)
+        return teleport_to_location(agent, target_coordinates)
+
+    space = getattr(agent.model, "space", None)
+    grid_or_space = None
+    if isinstance(grid, SingleGrid | MultiGrid):
+        grid_or_space = grid
+    elif isinstance(space, ContinuousSpace):
+        grid_or_space = space
+
+    if grid_or_space is not None:
         dx, dy = direction_map_xy[direction]
+        x, y = _get_agent_position(agent)
+        new_pos = (x + dx, y + dy)
 
-    x, y = _get_agent_position(agent)
-
-    new_pos = (x + dx, y + dy)
-
-    # Guard against out-of-bounds moves and return a friendly message
-    # instead of letting the underlying grid raise a cryptic exception.
-    if isinstance(grid, OrthogonalMooreGrid | OrthogonalVonNeumannGrid):
-        if new_pos not in grid._cells:
-            return (
-                f"Agent {agent.unique_id} is at the boundary and cannot move "
-                f"{direction}. Try a different direction."
-            )
-    elif isinstance(grid, SingleGrid | MultiGrid):
-        nx, ny = new_pos
-        if not (0 <= nx < grid.width and 0 <= ny < grid.height):
+        if grid_or_space.torus:
+            new_pos = grid_or_space.torus_adj(new_pos)
+        elif grid_or_space.out_of_bounds(new_pos):
             return (
                 f"Agent {agent.unique_id} is at the boundary and cannot move "
                 f"{direction}. Try a different direction."
             )
 
-    target_coordinates = tuple(new_pos)
-    teleport_to_location(agent, target_coordinates)
-    return f"agent {agent.unique_id} moved to {target_coordinates}."
+        if isinstance(grid_or_space, SingleGrid) and not grid_or_space.is_cell_empty(
+            new_pos
+        ):
+            return (
+                f"Agent {agent.unique_id} cannot move {direction} because "
+                "the target cell is occupied."
+            )
+
+        target_coordinates = tuple(new_pos)
+        return teleport_to_location(agent, target_coordinates)
+
+    raise ValueError(
+        "Unsupported environment for move_one_step. Expected SingleGrid, "
+        "MultiGrid, OrthogonalMooreGrid, OrthogonalVonNeumannGrid, or "
+        "ContinuousSpace."
+    )
 
 
 @tool
@@ -138,6 +177,13 @@ def teleport_to_location(
 
     elif isinstance(agent.model.space, ContinuousSpace):
         agent.model.space.move_agent(agent, target_coordinates)
+
+    else:
+        raise ValueError(
+            "Unsupported environment for teleport_to_location. Expected "
+            "SingleGrid, MultiGrid, OrthogonalMooreGrid, "
+            "OrthogonalVonNeumannGrid, or ContinuousSpace."
+        )
 
     return f"agent {agent.unique_id} moved to {target_coordinates}."
 

--- a/mesa_llm/tools/inbuilt_tools.py
+++ b/mesa_llm/tools/inbuilt_tools.py
@@ -89,6 +89,23 @@ def move_one_step(agent: "LLMAgent", direction: str) -> str:
     x, y = _get_agent_position(agent)
 
     new_pos = (x + dx, y + dy)
+
+    # Guard against out-of-bounds moves and return a friendly message
+    # instead of letting the underlying grid raise a cryptic exception.
+    if isinstance(grid, OrthogonalMooreGrid | OrthogonalVonNeumannGrid):
+        if new_pos not in grid._cells:
+            return (
+                f"Agent {agent.unique_id} is at the boundary and cannot move "
+                f"{direction}. Try a different direction."
+            )
+    elif isinstance(grid, SingleGrid | MultiGrid):
+        nx, ny = new_pos
+        if not (0 <= nx < grid.width and 0 <= ny < grid.height):
+            return (
+                f"Agent {agent.unique_id} is at the boundary and cannot move "
+                f"{direction}. Try a different direction."
+            )
+
     target_coordinates = tuple(new_pos)
     teleport_to_location(agent, target_coordinates)
     return f"agent {agent.unique_id} moved to {target_coordinates}."

--- a/tests/test_tools/test_inbuilt_tools.py
+++ b/tests/test_tools/test_inbuilt_tools.py
@@ -201,3 +201,69 @@ def test_move_one_step_on_continuousspace():
 
     assert agent.pos == (2.0, 3.0)
     assert result == "agent 6 moved to (2.0, 3.0)."
+
+
+# --- boundary guard tests -------------------------------------------------------
+# Without the boundary check added to move_one_step, all three tests below would
+# either raise a GridException (SingleGrid/MultiGrid) or a KeyError
+# (OrthogonalMooreGrid) instead of returning the friendly message.
+
+
+def test_move_one_step_boundary_singlegrid_north():
+    """Agent at top edge of SingleGrid trying to go North gets a clear message."""
+    model = DummyModel()
+    model.grid = SingleGrid(width=5, height=5, torus=False)
+
+    agent = DummyAgent(unique_id=20, model=model)
+    model.agents.append(agent)
+    model.grid.place_agent(agent, (2, 4))  # y=4 is the top edge
+
+    result = move_one_step(agent, "North")
+
+    # agent should not have moved
+    assert agent.pos == (2, 4)
+    assert "boundary" in result.lower()
+    assert "North" in result
+
+
+def test_move_one_step_boundary_multigrid_west():
+    """Agent at left edge of MultiGrid trying to go West gets a clear message."""
+    model = DummyModel()
+    model.grid = MultiGrid(width=5, height=5, torus=False)
+
+    agent = DummyAgent(unique_id=21, model=model)
+    model.agents.append(agent)
+    model.grid.place_agent(agent, (0, 2))  # x=0 is the left edge
+
+    result = move_one_step(agent, "West")
+
+    assert agent.pos == (0, 2)
+    assert "boundary" in result.lower()
+    assert "West" in result
+
+
+def test_move_one_step_boundary_orthogonal_grid():
+    """Agent at edge of OrthogonalMooreGrid with no cell in that direction gets a clear message."""
+
+    class _DummyOrthogonalGrid(OrthogonalMooreGrid):
+        pass
+
+    orth_grid = object.__new__(_DummyOrthogonalGrid)
+    start = (0, 1)
+    start_cell = SimpleNamespace(coordinate=start, agents=[])
+    # (-1, 1) does not exist - simulates the grid boundary
+    orth_grid._cells = {start: start_cell}
+
+    model = DummyModel()
+    model.grid = orth_grid
+
+    agent = DummyAgent(unique_id=22, model=model)
+    agent.cell = start_cell
+    model.agents.append(agent)
+
+    result = move_one_step(agent, "North")
+
+    # cell should be unchanged
+    assert agent.cell is start_cell
+    assert "boundary" in result.lower()
+    assert "North" in result

--- a/tests/test_tools/test_inbuilt_tools.py
+++ b/tests/test_tools/test_inbuilt_tools.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
-from mesa.discrete_space import OrthogonalMooreGrid
+from mesa.discrete_space import OrthogonalMooreGrid, OrthogonalVonNeumannGrid
 from mesa.space import ContinuousSpace, MultiGrid, SingleGrid
 
 from mesa_llm.tools.inbuilt_tools import (
@@ -61,6 +61,8 @@ def test_teleport_to_location_on_orthogonal_grid_without_constructor():
         pass
 
     orth_grid = object.__new__(_DummyOrthogonalGrid)
+    orth_grid.torus = False
+    orth_grid.dimensions = (3, 3)
     target = (1, 1)
     dummy_cell = SimpleNamespace(coordinate=target, agents=[])
     orth_grid._cells = {target: dummy_cell}
@@ -82,11 +84,18 @@ def test_move_one_step_on_orthogonal_grid_without_constructor():
         pass
 
     orth_grid = object.__new__(_DummyOrthogonalGrid)
+    orth_grid.torus = False
+    orth_grid.dimensions = (5, 5)
     start_target = (1, 1)
     # mesa.discrete_space grids use (row, col), so North decrements row.
     end_target = (0, 1)
-    start_cell = SimpleNamespace(coordinate=start_target, agents=[])
-    end_cell = SimpleNamespace(coordinate=end_target, agents=[])
+    start_cell = SimpleNamespace(
+        coordinate=start_target, agents=[], connections={}, is_full=False
+    )
+    end_cell = SimpleNamespace(
+        coordinate=end_target, agents=[], connections={}, is_full=False
+    )
+    start_cell.connections[(-1, 0)] = end_cell
     orth_grid._cells = {start_target: start_cell, end_target: end_cell}
 
     model = DummyModel()
@@ -107,11 +116,18 @@ def test_move_one_step_east_on_orthogonal_grid_without_constructor():
         pass
 
     orth_grid = object.__new__(_DummyOrthogonalGrid)
+    orth_grid.torus = False
+    orth_grid.dimensions = (5, 5)
     start_target = (1, 1)
     # mesa.discrete_space grids use (row, col), so East increments col.
     end_target = (1, 2)
-    start_cell = SimpleNamespace(coordinate=start_target, agents=[])
-    end_cell = SimpleNamespace(coordinate=end_target, agents=[])
+    start_cell = SimpleNamespace(
+        coordinate=start_target, agents=[], connections={}, is_full=False
+    )
+    end_cell = SimpleNamespace(
+        coordinate=end_target, agents=[], connections={}, is_full=False
+    )
+    start_cell.connections[(0, 1)] = end_cell
     orth_grid._cells = {start_target: start_cell, end_target: end_cell}
 
     model = DummyModel()
@@ -172,6 +188,70 @@ def test_move_one_step_invalid_direction():
         move_one_step(agent, "north east")
 
 
+def test_move_one_step_unsupported_environment():
+    model = DummyModel()
+    model.grid = None
+    model.space = None
+
+    agent = DummyAgent(unique_id=4, model=model)
+    model.agents.append(agent)
+    agent.pos = (1, 1)
+
+    with pytest.raises(ValueError, match="Unsupported environment"):
+        move_one_step(agent, "North")
+
+
+def test_move_one_step_unsupported_non_none_environment():
+    class _UnsupportedGrid:
+        pass
+
+    class _UnsupportedSpace:
+        pass
+
+    model = DummyModel()
+    model.grid = _UnsupportedGrid()
+    model.space = _UnsupportedSpace()
+
+    agent = DummyAgent(unique_id=32, model=model)
+    model.agents.append(agent)
+    agent.pos = (1, 1)
+
+    with pytest.raises(ValueError, match="Unsupported environment"):
+        move_one_step(agent, "North")
+
+
+def test_teleport_to_location_unsupported_environment():
+    model = DummyModel()
+    model.grid = None
+    model.space = None
+
+    agent = DummyAgent(unique_id=8, model=model)
+    model.agents.append(agent)
+    agent.pos = (1, 1)
+
+    with pytest.raises(ValueError, match="Unsupported environment"):
+        teleport_to_location(agent, [2, 2])
+
+
+def test_teleport_to_location_unsupported_non_none_environment():
+    class _UnsupportedGrid:
+        pass
+
+    class _UnsupportedSpace:
+        pass
+
+    model = DummyModel()
+    model.grid = _UnsupportedGrid()
+    model.space = _UnsupportedSpace()
+
+    agent = DummyAgent(unique_id=33, model=model)
+    model.agents.append(agent)
+    agent.pos = (1, 1)
+
+    with pytest.raises(ValueError, match="Unsupported environment"):
+        teleport_to_location(agent, [2, 2])
+
+
 def test_teleport_to_location_on_continuousspace():
     model = DummyModel()
     model.grid = None
@@ -185,6 +265,54 @@ def test_teleport_to_location_on_continuousspace():
 
     assert agent.pos == (5.0, 7.0)
     assert out == "agent 5 moved to (5.0, 7.0)."
+
+
+def test_teleport_to_location_singlegrid_occupied_target_raises():
+    model = DummyModel()
+    model.grid = SingleGrid(width=4, height=4, torus=False)
+
+    moving_agent = DummyAgent(unique_id=34, model=model)
+    blocking_agent = DummyAgent(unique_id=35, model=model)
+    model.agents.extend([moving_agent, blocking_agent])
+    model.grid.place_agent(moving_agent, (1, 1))
+    model.grid.place_agent(blocking_agent, (1, 2))
+
+    with pytest.raises(Exception, match="Cell not empty"):
+        teleport_to_location(moving_agent, [1, 2])
+
+
+def test_teleport_to_location_singlegrid_out_of_bounds_raises():
+    model = DummyModel()
+    model.grid = SingleGrid(width=4, height=4, torus=False)
+
+    agent = DummyAgent(unique_id=36, model=model)
+    model.agents.append(agent)
+    model.grid.place_agent(agent, (1, 1))
+
+    with pytest.raises(Exception, match="Point out of bounds"):
+        teleport_to_location(agent, [-1, 1])
+
+
+def test_teleport_to_location_orthogonal_missing_cell_raises_keyerror():
+    class _DummyOrthogonalGrid(OrthogonalMooreGrid):
+        pass
+
+    orth_grid = object.__new__(_DummyOrthogonalGrid)
+    orth_grid.torus = False
+    orth_grid.dimensions = (3, 3)
+    start = (1, 1)
+    start_cell = SimpleNamespace(coordinate=start, agents=[], is_full=False)
+    orth_grid._cells = {start: start_cell}
+
+    model = DummyModel()
+    model.grid = orth_grid
+
+    agent = DummyAgent(unique_id=37, model=model)
+    agent.cell = start_cell
+    model.agents.append(agent)
+
+    with pytest.raises(KeyError):
+        teleport_to_location(agent, [0, 1])
 
 
 def test_move_one_step_on_continuousspace():
@@ -203,10 +331,35 @@ def test_move_one_step_on_continuousspace():
     assert result == "agent 6 moved to (2.0, 3.0)."
 
 
-# --- boundary guard tests -------------------------------------------------------
-# Without the boundary check added to move_one_step, all three tests below would
-# either raise a GridException (SingleGrid/MultiGrid) or a KeyError
-# (OrthogonalMooreGrid) instead of returning the friendly message.
+def test_move_one_step_boundary_on_continuousspace():
+    model = DummyModel()
+    model.grid = None
+    model.space = ContinuousSpace(x_max=10.0, y_max=10.0, torus=False)
+
+    agent = DummyAgent(unique_id=30, model=model)
+    model.agents.append(agent)
+    model.space.place_agent(agent, (2.0, 9.0))
+
+    result = move_one_step(agent, "North")
+
+    assert agent.pos == (2.0, 9.0)
+    assert "boundary" in result.lower()
+    assert "North" in result
+
+
+def test_move_one_step_torus_wrap_on_continuousspace():
+    model = DummyModel()
+    model.grid = None
+    model.space = ContinuousSpace(x_max=10.0, y_max=10.0, torus=True)
+
+    agent = DummyAgent(unique_id=31, model=model)
+    model.agents.append(agent)
+    model.space.place_agent(agent, (2.0, 9.0))
+
+    result = move_one_step(agent, "North")
+
+    assert agent.pos == (2.0, 0.0)
+    assert result == "agent 31 moved to (2.0, 0.0)."
 
 
 def test_move_one_step_boundary_singlegrid_north():
@@ -226,6 +379,20 @@ def test_move_one_step_boundary_singlegrid_north():
     assert "North" in result
 
 
+def test_move_one_step_torus_wrap_singlegrid_north():
+    model = DummyModel()
+    model.grid = SingleGrid(width=5, height=5, torus=True)
+
+    agent = DummyAgent(unique_id=23, model=model)
+    model.agents.append(agent)
+    model.grid.place_agent(agent, (2, 4))
+
+    result = move_one_step(agent, "North")
+
+    assert agent.pos == (2, 0)
+    assert result == "agent 23 moved to (2, 0)."
+
+
 def test_move_one_step_boundary_multigrid_west():
     """Agent at left edge of MultiGrid trying to go West gets a clear message."""
     model = DummyModel()
@@ -242,6 +409,38 @@ def test_move_one_step_boundary_multigrid_west():
     assert "West" in result
 
 
+def test_move_one_step_torus_wrap_multigrid_west():
+    model = DummyModel()
+    model.grid = MultiGrid(width=5, height=5, torus=True)
+
+    agent = DummyAgent(unique_id=24, model=model)
+    model.agents.append(agent)
+    model.grid.place_agent(agent, (0, 2))
+
+    result = move_one_step(agent, "West")
+
+    assert agent.pos == (4, 2)
+    assert result == "agent 24 moved to (4, 2)."
+
+
+def test_move_one_step_singlegrid_occupied_target():
+    model = DummyModel()
+    model.grid = SingleGrid(width=5, height=5, torus=False)
+
+    moving_agent = DummyAgent(unique_id=25, model=model)
+    blocking_agent = DummyAgent(unique_id=26, model=model)
+    model.agents.extend([moving_agent, blocking_agent])
+    model.grid.place_agent(moving_agent, (2, 2))
+    model.grid.place_agent(blocking_agent, (2, 3))
+
+    result = move_one_step(moving_agent, "North")
+
+    assert moving_agent.pos == (2, 2)
+    assert blocking_agent.pos == (2, 3)
+    assert "occupied" in result.lower()
+    assert "North" in result
+
+
 def test_move_one_step_boundary_orthogonal_grid():
     """Agent at edge of OrthogonalMooreGrid with no cell in that direction gets a clear message."""
 
@@ -249,9 +448,12 @@ def test_move_one_step_boundary_orthogonal_grid():
         pass
 
     orth_grid = object.__new__(_DummyOrthogonalGrid)
+    orth_grid.torus = False
+    orth_grid.dimensions = (5, 5)
     start = (0, 1)
-    start_cell = SimpleNamespace(coordinate=start, agents=[])
-    # (-1, 1) does not exist - simulates the grid boundary
+    start_cell = SimpleNamespace(
+        coordinate=start, agents=[], connections={}, is_full=False
+    )
     orth_grid._cells = {start: start_cell}
 
     model = DummyModel()
@@ -267,3 +469,116 @@ def test_move_one_step_boundary_orthogonal_grid():
     assert agent.cell is start_cell
     assert "boundary" in result.lower()
     assert "North" in result
+
+
+def test_move_one_step_boundary_orthogonal_torus_missing_wrapped_cell():
+    class _DummyOrthogonalGrid(OrthogonalMooreGrid):
+        pass
+
+    orth_grid = object.__new__(_DummyOrthogonalGrid)
+    orth_grid.torus = True
+    orth_grid.dimensions = (3, 3)
+    start = (0, 0)
+    start_cell = SimpleNamespace(coordinate=start, agents=[], is_full=False)
+    # Wrapped target for North would be (2, 0), but it is intentionally absent.
+    orth_grid._cells = {start: start_cell}
+
+    model = DummyModel()
+    model.grid = orth_grid
+
+    agent = DummyAgent(unique_id=38, model=model)
+    agent.cell = start_cell
+    model.agents.append(agent)
+
+    result = move_one_step(agent, "North")
+
+    assert agent.cell is start_cell
+    assert "boundary" in result.lower()
+    assert "North" in result
+
+
+def test_move_one_step_full_target_orthogonal_grid():
+    class _DummyOrthogonalGrid(OrthogonalMooreGrid):
+        pass
+
+    orth_grid = object.__new__(_DummyOrthogonalGrid)
+    orth_grid.torus = False
+    orth_grid.dimensions = (5, 5)
+    start = (1, 1)
+    end = (0, 1)
+    start_cell = SimpleNamespace(
+        coordinate=start, agents=[], connections={}, is_full=False
+    )
+    full_target_cell = SimpleNamespace(
+        coordinate=end,
+        agents=[SimpleNamespace(unique_id=99)],
+        connections={},
+        is_full=True,
+    )
+    start_cell.connections[(-1, 0)] = full_target_cell
+    orth_grid._cells = {start: start_cell, end: full_target_cell}
+
+    model = DummyModel()
+    model.grid = orth_grid
+
+    agent = DummyAgent(unique_id=27, model=model)
+    agent.cell = start_cell
+    model.agents.append(agent)
+
+    result = move_one_step(agent, "North")
+
+    assert agent.cell is start_cell
+    assert "full" in result.lower()
+    assert "North" in result
+
+
+def test_move_one_step_diagonal_on_orthogonal_vonneumann_grid():
+    class _DummyOrthogonalVonNeumannGrid(OrthogonalVonNeumannGrid):
+        pass
+
+    orth_grid = object.__new__(_DummyOrthogonalVonNeumannGrid)
+    orth_grid.torus = False
+    orth_grid.dimensions = (5, 5)
+    start = (2, 2)
+    end = (1, 3)  # NorthEast
+    start_cell = SimpleNamespace(coordinate=start, agents=[], is_full=False)
+    end_cell = SimpleNamespace(coordinate=end, agents=[], is_full=False)
+    orth_grid._cells = {start: start_cell, end: end_cell}
+
+    model = DummyModel()
+    model.grid = orth_grid
+
+    agent = DummyAgent(unique_id=28, model=model)
+    agent.cell = start_cell
+    model.agents.append(agent)
+
+    result = move_one_step(agent, "NorthEast")
+
+    assert agent.cell is end_cell
+    assert result == "agent 28 moved to (1, 3)."
+
+
+def test_move_one_step_torus_wrap_orthogonal_grid():
+    class _DummyOrthogonalGrid(OrthogonalMooreGrid):
+        pass
+
+    orth_grid = object.__new__(_DummyOrthogonalGrid)
+    orth_grid.torus = True
+    orth_grid.dimensions = (3, 3)
+    start = (0, 0)
+    end = (2, 2)  # NorthWest wraps on torus
+    start_cell = SimpleNamespace(coordinate=start, agents=[], is_full=False)
+    wrapped_cell = SimpleNamespace(coordinate=end, agents=[], is_full=False)
+    orth_grid._cells = {start: start_cell, end: wrapped_cell}
+
+    model = DummyModel()
+    model.grid = orth_grid
+
+    agent = DummyAgent(unique_id=29, model=model)
+    agent.cell = start_cell
+    model.agents.append(agent)
+
+    result = move_one_step(agent, "NorthWest")
+
+    assert agent.cell is wrapped_cell
+    assert result == "agent 29 moved to (2, 2)."


### PR DESCRIPTION
**Description**

Currently when an agent tries to move outside the grid bounds, the underlying Mesa grid throws an exception (`KeyError` on orthogonal grids, `GridException` on SingleGrid/MultiGrid). This gets swallowed by `ToolManager._process_tool_call` and returned to the LLM as just `"Error: (3, 5)"` or similar — which tells the agent absolutely nothing useful.

This PR adds a boundary check directly inside `move_one_step` before delegating to `teleport_to_location`, so instead of that cryptic error the LLM gets back:

> `"Agent 3 is at the boundary and cannot move North. Try a different direction."`

Which actually lets the agent reason and retry with a valid direction.

**What changed**

- Added a pre-move bounds check in `move_one_step` for `SingleGrid`/`MultiGrid` (using `grid.width` and `grid.height`) and for `OrthogonalMooreGrid`/`OrthogonalVonNeumannGrid` (using `grid._cells` membership)
- No changes to `teleport_to_location` or `ToolManager` — the fix is scoped to where the grid type is already known
- Added 3 new unit tests in test_inbuilt_tools.py

**Why not fix it in `ToolManager`?**

The generic except block in `_process_tool_call` is intentionally broad — it's not the right place to handle domain-specific logic. The boundary knowledge lives in `move_one_step` so thats where the fix belongs.

**Tests**

Added 3 tests that all **fail without this PR** (raising `Exception: Point out of bounds, and space non-toroidal.` or `KeyError`) and **pass after it**:

| Test | Scenario |
|---|---|
| `test_move_one_step_boundary_singlegrid_north` | Agent at top edge `y=4` of a 5×5 `SingleGrid` moving North |
| `test_move_one_step_boundary_multigrid_west` | Agent at left edge `x=0` of a 5×5 `MultiGrid` moving West |
| `test_move_one_step_boundary_orthogonal_grid` | Agent at row 0 of an `OrthogonalMooreGrid` with no cell above it |

Each test asserts two things: the agent didn't move, and the returned string contains `"boundary"` and the direction name so the LLM can act on it.


**without the fix**
```
FAILED test_move_one_step_boundary_singlegrid_north  - Exception: Point out of bounds, and space non-toroidal.
FAILED test_move_one_step_boundary_multigrid_west    - Exception: Point out of bounds, and space non-toroidal.
FAILED test_move_one_step_boundary_orthogonal_grid   - KeyError: (-1, 1)
```

**with the fix**
```
12 passed in 0.03s
```