### PR TITLE
Fix/ handle different LLM encodings for listener IDs in speak_to

### DIFF
--- a/mesa_llm/tools/inbuilt_tools.py
+++ b/mesa_llm/tools/inbuilt_tools.py
@@ -1,3 +1,4 @@
+import ast
 from typing import TYPE_CHECKING, Any
 
 from mesa.discrete_space import (
@@ -137,6 +138,27 @@ def speak_to(
         listener_agents_unique_ids: The unique ids of the agents receiving the message
         message: The message to send
     """
+
+    # Normalize: the LLM may pass IDs as a JSON string (e.g. '[5, 9]') or a
+    # bare int rather than a proper list[int], which would silently produce
+    # an empty recipient list.
+    if isinstance(listener_agents_unique_ids, str):
+        try:
+            listener_agents_unique_ids = ast.literal_eval(listener_agents_unique_ids)
+        except Exception:
+            listener_agents_unique_ids = []
+
+    if isinstance(listener_agents_unique_ids, int):
+        listener_agents_unique_ids = [listener_agents_unique_ids]
+
+    if listener_agents_unique_ids is None:
+        listener_agents_unique_ids = []
+
+    try:
+        listener_agents_unique_ids = [int(uid) for uid in listener_agents_unique_ids]
+    except Exception:
+        listener_agents_unique_ids = []
+
     listener_agents = [
         listener_agent
         for listener_agent in agent.model.agents

--- a/tests/test_tools/test_inbuilt_tools.py
+++ b/tests/test_tools/test_inbuilt_tools.py
@@ -416,6 +416,8 @@ def test_speak_to_handles_non_numeric_ids_in_list(mocker):
 
     r1.memory.add_to_memory.assert_not_called()
     assert ret is not None
+
+
 def test_move_one_step_boundary_on_continuousspace():
     model = DummyModel()
     model.grid = None

--- a/tests/test_tools/test_inbuilt_tools.py
+++ b/tests/test_tools/test_inbuilt_tools.py
@@ -201,3 +201,42 @@ def test_move_one_step_on_continuousspace():
 
     assert agent.pos == (2.0, 3.0)
     assert result == "agent 6 moved to (2.0, 3.0)."
+
+
+def test_speak_to_accepts_stringified_list(mocker):
+    """LLM sometimes serializes the list as a JSON string e.g. '[11, 12]'."""
+    model = DummyModel()
+
+    sender = DummyAgent(unique_id=10, model=model)
+    r1 = DummyAgent(unique_id=11, model=model)
+    r2 = DummyAgent(unique_id=12, model=model)
+
+    r1.memory = SimpleNamespace(add_to_memory=mocker.Mock())
+    r2.memory = SimpleNamespace(add_to_memory=mocker.Mock())
+
+    model.agents = [sender, r1, r2]
+
+    # Pass IDs as a stringified list — what the LLM often produces
+    ret = speak_to(sender, "[11, 12]", "hey")
+
+    r1.memory.add_to_memory.assert_called_once()
+    r2.memory.add_to_memory.assert_called_once()
+    assert "11" in ret and "12" in ret
+
+
+def test_speak_to_accepts_bare_int(mocker):
+    """LLM sometimes passes a single int instead of a list."""
+    model = DummyModel()
+
+    sender = DummyAgent(unique_id=10, model=model)
+    r1 = DummyAgent(unique_id=11, model=model)
+
+    r1.memory = SimpleNamespace(add_to_memory=mocker.Mock())
+
+    model.agents = [sender, r1]
+
+    # Pass a bare int — another common LLM encoding
+    ret = speak_to(sender, 11, "hey")
+
+    r1.memory.add_to_memory.assert_called_once()
+    assert "11" in ret

--- a/tests/test_tools/test_inbuilt_tools.py
+++ b/tests/test_tools/test_inbuilt_tools.py
@@ -240,3 +240,51 @@ def test_speak_to_accepts_bare_int(mocker):
 
     r1.memory.add_to_memory.assert_called_once()
     assert "11" in ret
+
+
+def test_speak_to_handles_none_ids(mocker):
+    """LLM occasionally omits the arg entirely, arriving as None — should not crash."""
+    model = DummyModel()
+
+    sender = DummyAgent(unique_id=10, model=model)
+    r1 = DummyAgent(unique_id=11, model=model)
+    r1.memory = SimpleNamespace(add_to_memory=mocker.Mock())
+    model.agents = [sender, r1]
+
+    # None should be treated as empty recipient list, no exception
+    ret = speak_to(sender, None, "hey")
+
+    r1.memory.add_to_memory.assert_not_called()
+    assert ret is not None
+
+
+def test_speak_to_handles_malformed_string_ids(mocker):
+    """ast.literal_eval fails on garbage strings — should fall back to empty list."""
+    model = DummyModel()
+
+    sender = DummyAgent(unique_id=10, model=model)
+    r1 = DummyAgent(unique_id=11, model=model)
+    r1.memory = SimpleNamespace(add_to_memory=mocker.Mock())
+    model.agents = [sender, r1]
+
+    # Completely unparsable string — no crash, no recipients
+    ret = speak_to(sender, "not a valid list at all", "hey")
+
+    r1.memory.add_to_memory.assert_not_called()
+    assert ret is not None
+
+
+def test_speak_to_handles_non_numeric_ids_in_list(mocker):
+    """If uid coercion to int fails — should fall back to empty list, no crash."""
+    model = DummyModel()
+
+    sender = DummyAgent(unique_id=10, model=model)
+    r1 = DummyAgent(unique_id=11, model=model)
+    r1.memory = SimpleNamespace(add_to_memory=mocker.Mock())
+    model.agents = [sender, r1]
+
+    # List that looks valid but has non-numeric strings inside
+    ret = speak_to(sender, ["alice", "bob"], "hey")
+
+    r1.memory.add_to_memory.assert_not_called()
+    assert ret is not None


### PR DESCRIPTION
**Description**

The `speak_to` tool expects `listener_agents_unique_ids` to be a `list[int]`, but LLMs often send it in different formats depending on how they serialize arguments:

- As a **stringified list**: `"[5, 9]"` (the LLM JSON-encodes it twice by mistake)
- As a **bare integer**: `5` (when there's only one recipient)
- As **None**: happens occasionaly when the LLM forgets the arg

Without this fix, the code raises a `TypeError` (e.g. `'in <string>' requires string as left operand, not int`) which gets caught by `ToolManager._process_tool_call` and returned to the LLM as a cryptic `"Error: ..."` — the message is never delivered and the LLM has no useful feedback to recover from.

This PR adds normalization logic to handle all three cases, so messages get through regaurdless of how the LLM formats the IDs.

**Example scenarios that now work:**

```python
# LLM sends a stringified list (common in chain-of-thought outputs)
speak_to(agent, "[11, 12]", "hey")  # now works, was TypeError before

# LLM sends a bare int (when generating single-recipient calls)
speak_to(agent, 11, "hey")  # now works, was TypeError before

# LLM sends None
speak_to(agent, None, "hey")  # now gracefully handles it
```

**Testing**

Added 5 new tests covering every normalization branch:

| Test | What it covers |
|---|---|
| `test_speak_to_accepts_stringified_list` | `"[11, 12]"` parsed via `ast.literal_eval` |
| `test_speak_to_accepts_bare_int` | `11` wrapped to `[11]` |
| `test_speak_to_handles_none_ids` | `None` treated as empty list |
| `test_speak_to_handles_malformed_string_ids` | garbage string falls back to `[]` |
| `test_speak_to_handles_non_numeric_ids_in_list` | `["alice", "bob"]` → `int()` fails → `[]` |

The first two fail without this PR (raise `TypeError`), the last three cover the except/fallback branches for full patch coverage. All existing tests still pass.