### PR TITLE
ToolManager.get_all_tools_schema() exposes every tool to the LLM regardless of agent state.

### DIFF
--- a/mesa_llm/__init__.py
+++ b/mesa_llm/__init__.py
@@ -9,6 +9,7 @@ from .parallel_stepping import (
 )
 from .reasoning.reasoning import Observation, Plan
 from .recording.record_model import record_model
+from .tools.tool_decorator import requires
 from .tools.tool_manager import ToolManager
 
 # Enable automatic parallel stepping when mesa_llm is imported
@@ -20,6 +21,7 @@ __all__ = [
     "ToolManager",
     "enable_automatic_parallel_stepping",
     "record_model",
+    "requires",
     "step_agents_parallel",
     "step_agents_parallel_sync",
 ]

--- a/mesa_llm/llm_agent.py
+++ b/mesa_llm/llm_agent.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 from mesa.agent import Agent
 from mesa.discrete_space import (
     OrthogonalMooreGrid,
@@ -78,6 +80,24 @@ class LLMAgent(Agent):
 
     def __str__(self):
         return f"LLMAgent {self.unique_id}"
+
+    def tool_filter(self, tool_name: str, tool_fn: Callable) -> bool:
+        """Determine whether a tool is available for this agent.
+
+        Override in subclasses to dynamically exclude tools based on
+        agent state.  Called by ``ToolManager.get_feasible_tools_schema``
+        and ``ToolManager.get_annotated_tools_schema`` *after* the
+        tool-level ``@requires`` checks have passed.
+
+        Args:
+            tool_name: The registered name of the tool.
+            tool_fn: The tool function object.
+
+        Returns:
+            ``True`` if the tool should be available, ``False`` to
+            exclude it.
+        """
+        return True
 
     async def aapply_plan(self, plan: Plan) -> list[dict]:
         """

--- a/mesa_llm/reasoning/cot.py
+++ b/mesa_llm/reasoning/cot.py
@@ -118,7 +118,9 @@ class CoTReasoning(Reasoning):
         llm.system_prompt = system_prompt
         rsp = llm.generate(
             prompt=prompt,
-            tool_schema=self.agent.tool_manager.get_all_tools_schema(selected_tools),
+            tool_schema=self.agent.tool_manager.get_annotated_tools_schema(
+                agent=self.agent, selected_tools=selected_tools
+            ),
             tool_choice="none",
         )
 
@@ -134,7 +136,9 @@ class CoTReasoning(Reasoning):
         llm.system_prompt = system_prompt
         rsp = llm.generate(
             prompt=chaining_message,
-            tool_schema=self.agent.tool_manager.get_all_tools_schema(selected_tools),
+            tool_schema=self.agent.tool_manager.get_feasible_tools_schema(
+                agent=self.agent, selected_tools=selected_tools
+            ),
             tool_choice="required",
         )
         response_message = rsp.choices[0].message
@@ -178,7 +182,9 @@ class CoTReasoning(Reasoning):
 
         rsp = await llm.agenerate(
             prompt=prompt,
-            tool_schema=self.agent.tool_manager.get_all_tools_schema(selected_tools),
+            tool_schema=self.agent.tool_manager.get_annotated_tools_schema(
+                agent=self.agent, selected_tools=selected_tools
+            ),
             tool_choice="none",
         )
 
@@ -194,7 +200,9 @@ class CoTReasoning(Reasoning):
         llm.system_prompt = system_prompt
         rsp = await llm.agenerate(
             prompt=chaining_message,
-            tool_schema=self.agent.tool_manager.get_all_tools_schema(selected_tools),
+            tool_schema=self.agent.tool_manager.get_feasible_tools_schema(
+                agent=self.agent, selected_tools=selected_tools
+            ),
             tool_choice="required",
         )
         response_message = rsp.choices[0].message

--- a/mesa_llm/reasoning/react.py
+++ b/mesa_llm/reasoning/react.py
@@ -82,8 +82,8 @@ class ReActReasoning(Reasoning):
         else:
             raise ValueError("No prompt provided and agent.step_prompt is None.")
 
-        selected_tools_schema = self.agent.tool_manager.get_all_tools_schema(
-            selected_tools
+        selected_tools_schema = self.agent.tool_manager.get_annotated_tools_schema(
+            agent=self.agent, selected_tools=selected_tools
         )
 
         # ---------------- generate the plan ----------------
@@ -132,8 +132,8 @@ class ReActReasoning(Reasoning):
         else:
             raise ValueError("No prompt provided and agent.step_prompt is None.")
 
-        selected_tools_schema = self.agent.tool_manager.get_all_tools_schema(
-            selected_tools
+        selected_tools_schema = self.agent.tool_manager.get_annotated_tools_schema(
+            agent=self.agent, selected_tools=selected_tools
         )
 
         # ---------------- generate the plan ----------------

--- a/mesa_llm/reasoning/reasoning.py
+++ b/mesa_llm/reasoning/reasoning.py
@@ -114,8 +114,8 @@ class Reasoning(ABC):
         self.agent.llm.system_prompt = system_prompt
         rsp = self.agent.llm.generate(
             prompt=chaining_message,
-            tool_schema=self.agent.tool_manager.get_all_tools_schema(
-                selected_tools=selected_tools
+            tool_schema=self.agent.tool_manager.get_feasible_tools_schema(
+                agent=self.agent, selected_tools=selected_tools
             ),
             tool_choice="required",
         )
@@ -137,8 +137,8 @@ class Reasoning(ABC):
         self.agent.llm.system_prompt = system_prompt
         rsp = await self.agent.llm.agenerate(
             prompt=chaining_message,
-            tool_schema=self.agent.tool_manager.get_all_tools_schema(
-                selected_tools=selected_tools
+            tool_schema=self.agent.tool_manager.get_feasible_tools_schema(
+                agent=self.agent, selected_tools=selected_tools
             ),
             tool_choice="required",
         )

--- a/mesa_llm/reasoning/rewoo.py
+++ b/mesa_llm/reasoning/rewoo.py
@@ -136,7 +136,9 @@ class ReWOOReasoning(Reasoning):
         llm.system_prompt = system_prompt
         rsp = llm.generate(
             prompt=prompt,
-            tool_schema=self.agent.tool_manager.get_all_tools_schema(selected_tools),
+            tool_schema=self.agent.tool_manager.get_annotated_tools_schema(
+                agent=self.agent, selected_tools=selected_tools
+            ),
             tool_choice="none",
         )
 
@@ -196,7 +198,9 @@ class ReWOOReasoning(Reasoning):
         llm.system_prompt = system_prompt
         rsp = await llm.agenerate(
             prompt=prompt,
-            tool_schema=self.agent.tool_manager.get_all_tools_schema(selected_tools),
+            tool_schema=self.agent.tool_manager.get_annotated_tools_schema(
+                agent=self.agent, selected_tools=selected_tools
+            ),
             tool_choice="none",
         )
 

--- a/mesa_llm/tools/inbuilt_tools.py
+++ b/mesa_llm/tools/inbuilt_tools.py
@@ -10,7 +10,7 @@ from mesa.space import (
     SingleGrid,
 )
 
-from mesa_llm.tools.tool_decorator import tool
+from mesa_llm.tools.tool_decorator import requires, tool
 
 if TYPE_CHECKING:
     from mesa_llm.llm_agent import LLMAgent
@@ -61,6 +61,20 @@ def _get_agent_position(agent: "LLMAgent") -> Any:
 
 
 @tool
+@requires(
+    lambda agent: (
+        getattr(agent, "pos", None) is not None
+        or getattr(getattr(agent, "cell", None), "coordinate", None) is not None
+    ),
+    reason="Agent has no position",
+)
+@requires(
+    lambda agent: (
+        getattr(agent.model, "grid", None) is not None
+        or getattr(agent.model, "space", None) is not None
+    ),
+    reason="Model has no grid or space",
+)
 def move_one_step(agent: "LLMAgent", direction: str) -> str:
     """
     Moves agents one step in specified cardinal/diagonal directions (North, South, East, West, NorthEast, NorthWest, SouthEast, SouthWest). Automatically handles different Mesa grid types including SingleGrid, MultiGrid, OrthogonalGrids, and ContinuousSpace.
@@ -151,6 +165,13 @@ def move_one_step(agent: "LLMAgent", direction: str) -> str:
 
 
 @tool
+@requires(
+    lambda agent: (
+        getattr(agent.model, "grid", None) is not None
+        or getattr(agent.model, "space", None) is not None
+    ),
+    reason="Model has no grid or space",
+)
 def teleport_to_location(
     agent: "LLMAgent",
     target_coordinates: list[int | float],

--- a/mesa_llm/tools/tool_decorator.py
+++ b/mesa_llm/tools/tool_decorator.py
@@ -25,6 +25,45 @@ def add_tool_callback(callback: Callable[[Callable], None]):
     _TOOL_CALLBACKS.append(callback)
 
 
+def requires(
+    check: Callable[..., bool],
+    reason: str = "Precondition not met",
+):
+    """Attach a feasibility check to a tool function.
+
+    When the ToolManager builds filtered schemas, every ``@requires``
+    check is evaluated.  If **any** check returns ``False`` the tool is
+    considered infeasible for that agent at that time.
+
+    Multiple ``@requires`` decorators can be stacked — they accumulate
+    as a list on ``fn.__tool_requires__``.
+
+    Args:
+        check: A callable ``(agent) -> bool``.  Receives the calling
+            agent and returns whether the precondition is satisfied.
+        reason: A short human-readable explanation shown to the LLM
+            when the tool is annotated as unavailable.
+
+    Returns:
+        The decorated function (unchanged except for the attached
+        metadata).
+
+    Example::
+
+        @tool
+        @requires(lambda agent: agent.pos is not None, reason="Agent has no position")
+        def move_one_step(agent, direction): ...
+    """
+
+    def decorator(fn: Callable) -> Callable:
+        if not hasattr(fn, "__tool_requires__"):
+            fn.__tool_requires__ = []
+        fn.__tool_requires__.append({"check": check, "reason": reason})
+        return fn
+
+    return decorator
+
+
 # ---------- helper functions ----------------------------------------------------
 class DocstringParsingError(Exception):
     """Raised when a Google-style docstring cannot be parsed."""

--- a/mesa_llm/tools/tool_manager.py
+++ b/mesa_llm/tools/tool_manager.py
@@ -1,5 +1,6 @@
 import asyncio
 import concurrent.futures
+import copy
 import inspect
 import json
 import logging
@@ -77,6 +78,86 @@ class ToolManager:
 
         else:
             return [fn.__tool_schema__ for fn in self.tools.values()]
+
+    def _check_tool_feasibility(
+        self, tool_name: str, tool_fn: Callable, agent: "LLMAgent"
+    ) -> tuple[bool, str | None]:
+        """Check whether a tool is feasible for the given agent.
+
+        Evaluates two layers:
+        1. Tool-level ``@requires`` decorators (structural preconditions).
+        2. Agent-level ``tool_filter()`` method (behavioral state).
+
+        Returns:
+            A tuple of ``(is_feasible, reason)``.  *reason* is ``None``
+            when feasible, or a human-readable string when not.
+        """
+        # Layer 1 — tool-level @requires checks
+        requirements = getattr(tool_fn, "__tool_requires__", [])
+        for req in requirements:
+            try:
+                if not req["check"](agent):
+                    return False, req["reason"]
+            except Exception:
+                # If the check itself errors (e.g. missing attribute),
+                # treat the tool as infeasible.
+                return False, req["reason"]
+
+        # Layer 2 — agent-level tool_filter() override
+        tool_filter = getattr(agent, "tool_filter", None)
+        if (
+            tool_filter is not None
+            and callable(tool_filter)
+            and not tool_filter(tool_name, tool_fn)
+        ):
+            return False, "Filtered by agent"
+
+        return True, None
+
+    def get_feasible_tools_schema(
+        self, agent: "LLMAgent", selected_tools: list[str] | None = None
+    ) -> list[dict]:
+        """Return schemas only for tools the agent can currently use.
+
+        Infeasible tools are excluded entirely from the returned list.
+        Intended for **executor** LLM calls where ``tool_choice="required"``
+        and the LLM must not attempt infeasible actions.
+        """
+        schemas: list[dict] = []
+        for name, fn in self.tools.items():
+            if selected_tools and name not in selected_tools:
+                continue
+            is_feasible, _ = self._check_tool_feasibility(name, fn, agent)
+            if is_feasible:
+                schemas.append(fn.__tool_schema__)
+        return schemas
+
+    def get_annotated_tools_schema(
+        self, agent: "LLMAgent", selected_tools: list[str] | None = None
+    ) -> list[dict]:
+        """Return all tool schemas with unavailable ones annotated.
+
+        Infeasible tools have their description prefixed with
+        ``[UNAVAILABLE: reason]`` so the LLM planner can reason about
+        *why* an action is blocked and plan alternatives.  Intended for
+        **planner** LLM calls where ``tool_choice="none"``.
+        """
+        schemas: list[dict] = []
+        for name, fn in self.tools.items():
+            if selected_tools and name not in selected_tools:
+                continue
+            is_feasible, reason = self._check_tool_feasibility(name, fn, agent)
+            if is_feasible:
+                schemas.append(fn.__tool_schema__)
+            else:
+                # Deep-copy to avoid mutating the original schema
+                annotated = copy.deepcopy(fn.__tool_schema__)
+                original_desc = annotated["function"].get("description", "")
+                annotated["function"]["description"] = (
+                    f"[UNAVAILABLE: {reason}] {original_desc}"
+                )
+                schemas.append(annotated)
+        return schemas
 
     def call(self, name: str, arguments: dict) -> str:
         """Call a registered tool with validated args"""

--- a/tests/test_integration/test_memory_reasoning.py
+++ b/tests/test_integration/test_memory_reasoning.py
@@ -38,7 +38,8 @@ def make_mock_agent(memory_instance, *, step_prompt="You are an agent in a simul
     agent.step_prompt = step_prompt
     agent.llm = Mock()
     agent.tool_manager = Mock()
-    agent.tool_manager.get_all_tools_schema.return_value = {}
+    agent.tool_manager.get_annotated_tools_schema.return_value = {}
+    agent.tool_manager.get_feasible_tools_schema.return_value = {}
     agent._step_display_data = {}
 
     # Wire memory
@@ -169,7 +170,8 @@ class TestCoTWithSTLTMemory:
         agent.step_prompt = "You are an agent"
         agent.llm = Mock()
         agent.tool_manager = Mock()
-        agent.tool_manager.get_all_tools_schema.return_value = {}
+        agent.tool_manager.get_annotated_tools_schema.return_value = {}
+        agent.tool_manager.get_feasible_tools_schema.return_value = {}
         agent._step_display_data = {}
 
         memory = STLTMemory(
@@ -244,7 +246,8 @@ class TestCoTWithEpisodicMemory:
         agent.step_prompt = "You are an agent"
         agent.llm = Mock()
         agent.tool_manager = Mock()
-        agent.tool_manager.get_all_tools_schema.return_value = {}
+        agent.tool_manager.get_annotated_tools_schema.return_value = {}
+        agent.tool_manager.get_feasible_tools_schema.return_value = {}
         agent._step_display_data = {}
 
         memory = EpisodicMemory(
@@ -328,7 +331,8 @@ class TestReActWithSTLTMemory:
         agent.step_prompt = "You are an agent"
         agent.llm = Mock()
         agent.tool_manager = Mock()
-        agent.tool_manager.get_all_tools_schema.return_value = {}
+        agent.tool_manager.get_annotated_tools_schema.return_value = {}
+        agent.tool_manager.get_feasible_tools_schema.return_value = {}
 
         memory = STLTMemory(
             agent=agent,
@@ -444,7 +448,8 @@ class TestReActWithEpisodicMemory:
         agent.step_prompt = "You are an agent"
         agent.llm = Mock()
         agent.tool_manager = Mock()
-        agent.tool_manager.get_all_tools_schema.return_value = {}
+        agent.tool_manager.get_annotated_tools_schema.return_value = {}
+        agent.tool_manager.get_feasible_tools_schema.return_value = {}
 
         memory = EpisodicMemory(
             agent=agent,
@@ -556,7 +561,7 @@ class TestReWOOWithSTLTMemory:
         agent.step_prompt = "You are an agent"
         agent.llm = Mock()
         agent.tool_manager = Mock()
-        agent.tool_manager.get_all_tools_schema.return_value = {}
+        agent.tool_manager.get_annotated_tools_schema.return_value = {}
         agent._step_display_data = {}
         default_obs = Observation(step=1, self_state={}, local_state={})
         agent.generate_obs = Mock(return_value=default_obs)
@@ -637,7 +642,7 @@ class TestReWOOWithEpisodicMemory:
         agent.step_prompt = "You are an agent"
         agent.llm = Mock()
         agent.tool_manager = Mock()
-        agent.tool_manager.get_all_tools_schema.return_value = {}
+        agent.tool_manager.get_annotated_tools_schema.return_value = {}
         agent._step_display_data = {}
         default_obs = Observation(step=1, self_state={}, local_state={})
         agent.generate_obs = Mock(return_value=default_obs)

--- a/tests/test_reasoning/test_cot.py
+++ b/tests/test_reasoning/test_cot.py
@@ -107,7 +107,8 @@ class TestCoTReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_annotated_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_feasible_tools_schema.return_value = {}
         mock_agent._step_display_data = {}  # Use real dict instead of Mock
         # Mock the LLM response for planning
         mock_plan_response = Mock()
@@ -132,7 +133,8 @@ class TestCoTReasoning:
         assert isinstance(result, Plan)
         assert result.ttl == 3
         # Check that tool schema was called with selected tools
-        assert mock_agent.tool_manager.get_all_tools_schema.call_count == 2
+        assert mock_agent.tool_manager.get_annotated_tools_schema.call_count == 1
+        assert mock_agent.tool_manager.get_feasible_tools_schema.call_count == 1
 
     def test_plan_no_prompt_error(self):
         """Test plan method raises error when no prompt is provided."""
@@ -158,7 +160,8 @@ class TestCoTReasoning:
         mock_agent.memory.aadd_to_memory = AsyncMock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_annotated_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_feasible_tools_schema.return_value = {}
         mock_agent._step_display_data = {}
 
         mock_plan_response = Mock()
@@ -192,7 +195,8 @@ class TestCoTReasoning:
         mock_agent.memory.aadd_to_memory = AsyncMock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_annotated_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_feasible_tools_schema.return_value = {}
         mock_agent._step_display_data = {}  # Use real dict instead of Mock
 
         # Mock the async LLM response for planning

--- a/tests/test_reasoning/test_react.py
+++ b/tests/test_reasoning/test_react.py
@@ -82,7 +82,7 @@ class TestReActReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_annotated_tools_schema.return_value = {}
 
         # Mock the LLM response
         mock_response = Mock()
@@ -117,7 +117,7 @@ class TestReActReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_annotated_tools_schema.return_value = {}
 
         # Mock the LLM response
         mock_response = Mock()
@@ -137,7 +137,9 @@ class TestReActReasoning:
         result = reasoning.plan(obs=obs, ttl=3, selected_tools=selected_tools)
 
         assert result == mock_plan
-        mock_agent.tool_manager.get_all_tools_schema.assert_called_with(selected_tools)
+        mock_agent.tool_manager.get_annotated_tools_schema.assert_called_with(
+            agent=mock_agent, selected_tools=selected_tools
+        )
         reasoning.execute_tool_call.assert_called_once_with(
             "test_action",
             selected_tools=selected_tools,
@@ -171,7 +173,7 @@ class TestReActReasoning:
         mock_agent.memory.aadd_to_memory = AsyncMock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_annotated_tools_schema.return_value = {}
 
         # Mock the async LLM response
         mock_response = Mock()

--- a/tests/test_reasoning/test_reasoning.py
+++ b/tests/test_reasoning/test_reasoning.py
@@ -56,7 +56,7 @@ class TestReasoningBase:
         mock_agent.llm.generate.return_value = mock_llm_response
 
         # Mock the Tool Manager
-        mock_agent.tool_manager.get_all_tools_schema.return_value = [
+        mock_agent.tool_manager.get_feasible_tools_schema.return_value = [
             {"schema": "example"}
         ]
 
@@ -81,8 +81,8 @@ class TestReasoningBase:
             tool_choice="required",
         )
         # Assert that the tool manager was asked for the correct schema
-        mock_agent.tool_manager.get_all_tools_schema.assert_called_once_with(
-            selected_tools=["tool1"]
+        mock_agent.tool_manager.get_feasible_tools_schema.assert_called_once_with(
+            agent=mock_agent, selected_tools=["tool1"]
         )
         # Assert that the output is a correctly formed Plan object
         assert isinstance(result_plan, Plan)
@@ -98,7 +98,7 @@ class TestReasoningBase:
         mock_llm_response.choices = [Mock()]
         mock_llm_response.choices[0].message = "Final LLM message"
         mock_agent.llm.generate.return_value = mock_llm_response
-        mock_agent.tool_manager.get_all_tools_schema.return_value = []
+        mock_agent.tool_manager.get_feasible_tools_schema.return_value = []
 
         class ConcreteReasoning(Reasoning):
             def plan(self, prompt=None, obs=None, ttl=1, selected_tools=None):

--- a/tests/test_reasoning/test_rewoo.py
+++ b/tests/test_reasoning/test_rewoo.py
@@ -85,7 +85,7 @@ class TestReWOOReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_annotated_tools_schema.return_value = {}
 
         # Mock the LLM response for planning
         mock_plan_response = Mock()
@@ -139,7 +139,7 @@ class TestReWOOReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_annotated_tools_schema.return_value = {}
 
         # Mock the LLM response for planning
         mock_plan_response = Mock()
@@ -177,7 +177,7 @@ class TestReWOOReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_annotated_tools_schema.return_value = {}
 
         # Mock the LLM response for planning
         mock_plan_response = Mock()
@@ -201,7 +201,9 @@ class TestReWOOReasoning:
         result = reasoning.plan(selected_tools=selected_tools)
 
         assert isinstance(result, Plan)
-        mock_agent.tool_manager.get_all_tools_schema.assert_called_with(selected_tools)
+        mock_agent.tool_manager.get_annotated_tools_schema.assert_called_with(
+            agent=mock_agent, selected_tools=selected_tools
+        )
 
     def test_plan_no_prompt_error(self):
         """Test plan method raises error when no prompt is provided."""
@@ -232,7 +234,7 @@ class TestReWOOReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_annotated_tools_schema.return_value = {}
 
         # Mock the LLM response for planning
         mock_plan_response = Mock()
@@ -295,7 +297,7 @@ class TestReWOOReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_annotated_tools_schema.return_value = {}
 
         mock_plan_response = Mock()
         mock_plan_response.choices = [Mock()]
@@ -345,7 +347,7 @@ class TestReWOOReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_annotated_tools_schema.return_value = {}
 
         mock_plan_response = Mock()
         mock_plan_response.choices = [Mock()]
@@ -385,7 +387,7 @@ class TestReWOOReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_annotated_tools_schema.return_value = {}
 
         mock_plan_response = Mock()
         mock_plan_response.choices = [Mock()]
@@ -429,7 +431,7 @@ class TestReWOOReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_annotated_tools_schema.return_value = {}
 
         mock_plan_response = Mock()
         mock_plan_response.choices = [Mock()]
@@ -455,7 +457,9 @@ class TestReWOOReasoning:
         )
 
         assert isinstance(result, Plan)
-        mock_agent.tool_manager.get_all_tools_schema.assert_called_with(selected_tools)
+        mock_agent.tool_manager.get_annotated_tools_schema.assert_called_with(
+            agent=mock_agent, selected_tools=selected_tools
+        )
 
     def test_aplan_with_no_tool_calls(self):
         """Test aplan method when execution returns no tool calls."""
@@ -469,7 +473,7 @@ class TestReWOOReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_annotated_tools_schema.return_value = {}
 
         mock_plan_response = Mock()
         mock_plan_response.choices = [Mock()]
@@ -507,7 +511,7 @@ class TestReWOOReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_annotated_tools_schema.return_value = {}
 
         mock_plan_response = Mock()
         mock_plan_response.choices = [Mock()]


### PR DESCRIPTION
## Fix
Closes: https://github.com/mesa/mesa-llm/issues/148

### Changes

- Added `@requires` decorator so tools can declare strict requirements  
  (e.g., `move_one_step` requires an agent position and a model grid).

- Added `tool_filter(tool_name, tool_fn)` method to `LLMAgent`  
  allowing users to dynamically block tools based on agent state  
  (e.g., disable movement when energy is `0`).

- Planners (**CoT**, **ReAct**, **ReWOO**) now use `get_annotated_tools_schema()`  
  - All tools remain visible  
  - Unavailable tools are labeled: `[UNAVAILABLE: reason]`  
  - Helps planners reason about alternatives.

- Executors (tool-calling phase) now use `get_feasible_tools_schema()`  
  - Unavailable tools are removed completely  
  - Prevents the LLM from selecting impossible actions and crashing the simulation.

### Tests

Patch tests added and passing successfully.

![test-results](https://github.com/user-attachments/assets/0f0043e6-8fd8-46a0-8d06-083623e45732)