### PR TITLE
fix: apply_plan() flattens multiple tool call results

### DIFF
--- a/mesa_llm/llm_agent.py
+++ b/mesa_llm/llm_agent.py
@@ -92,10 +92,14 @@ class LLMAgent(Agent):
         await self.memory.aadd_to_memory(
             type="action",
             content={
-                k: v
-                for tool_call in tool_call_resp
-                for k, v in tool_call.items()
-                if k not in ["tool_call_id", "role"]
+                "tool_calls": [
+                    {
+                        k: v
+                        for k, v in tc.items()
+                        if k not in ["tool_call_id", "role"]
+                    }
+                    for tc in tool_call_resp
+                ]
             },
         )
 
@@ -117,10 +121,14 @@ class LLMAgent(Agent):
         self.memory.add_to_memory(
             type="action",
             content={
-                k: v
-                for tool_call in tool_call_resp
-                for k, v in tool_call.items()
-                if k not in ["tool_call_id", "role"]
+                "tool_calls": [
+                    {
+                        k: v
+                        for k, v in tc.items()
+                        if k not in ["tool_call_id", "role"]
+                    }
+                    for tc in tool_call_resp
+                ]
             },
         )
 

--- a/mesa_llm/llm_agent.py
+++ b/mesa_llm/llm_agent.py
@@ -93,11 +93,7 @@ class LLMAgent(Agent):
             type="action",
             content={
                 "tool_calls": [
-                    {
-                        k: v
-                        for k, v in tc.items()
-                        if k not in ["tool_call_id", "role"]
-                    }
+                    {k: v for k, v in tc.items() if k not in ["tool_call_id", "role"]}
                     for tc in tool_call_resp
                 ]
             },
@@ -122,11 +118,7 @@ class LLMAgent(Agent):
             type="action",
             content={
                 "tool_calls": [
-                    {
-                        k: v
-                        for k, v in tc.items()
-                        if k not in ["tool_call_id", "role"]
-                    }
+                    {k: v for k, v in tc.items() if k not in ["tool_call_id", "role"]}
                     for tc in tool_call_resp
                 ]
             },

--- a/mesa_llm/memory/memory.py
+++ b/mesa_llm/memory/memory.py
@@ -50,6 +50,17 @@ class MemoryEntry:
             lines.append(f"\n[bold cyan][{key.title()}][/bold cyan]")
             if isinstance(value, dict):
                 lines.extend(format_nested_dict(value, 1))
+            elif isinstance(value, list):
+                for i, item in enumerate(value):
+                    if isinstance(item, dict):
+                        lines.append(
+                            f"   [blue]├──[/blue] [cyan]({i + 1})[/cyan]"
+                        )
+                        lines.extend(format_nested_dict(item, 2))
+                    else:
+                        lines.append(
+                            f"   [blue]├──[/blue] [cyan]{item}[/cyan]"
+                        )
             else:
                 lines.append(f"   [blue]└──[/blue] [cyan]{value} :[/cyan]")
 

--- a/mesa_llm/memory/memory.py
+++ b/mesa_llm/memory/memory.py
@@ -53,14 +53,10 @@ class MemoryEntry:
             elif isinstance(value, list):
                 for i, item in enumerate(value):
                     if isinstance(item, dict):
-                        lines.append(
-                            f"   [blue]├──[/blue] [cyan]({i + 1})[/cyan]"
-                        )
+                        lines.append(f"   [blue]├──[/blue] [cyan]({i + 1})[/cyan]")
                         lines.extend(format_nested_dict(item, 2))
                     else:
-                        lines.append(
-                            f"   [blue]├──[/blue] [cyan]{item}[/cyan]"
-                        )
+                        lines.append(f"   [blue]├──[/blue] [cyan]{item}[/cyan]")
             else:
                 lines.append(f"   [blue]└──[/blue] [cyan]{value} :[/cyan]")
 

--- a/mesa_llm/memory/memory.py
+++ b/mesa_llm/memory/memory.py
@@ -35,6 +35,19 @@ class MemoryEntry:
                 if isinstance(value, dict):
                     lines.append(f"{indent}[blue]└──[/blue] [cyan]{key} :[/cyan]")
                     lines.extend(format_nested_dict(value, indent_level + 1))
+                elif isinstance(value, list):
+                    lines.append(f"{indent}[blue]└──[/blue] [cyan]{key} :[/cyan]")
+                    next_indent = "   " * (indent_level + 1)
+                    for i, item in enumerate(value):
+                        if isinstance(item, dict):
+                            lines.append(
+                                f"{next_indent}[blue]├──[/blue] [cyan]({i + 1})[/cyan]"
+                            )
+                            lines.extend(format_nested_dict(item, indent_level + 2))
+                        else:
+                            lines.append(
+                                f"{next_indent}[blue]├──[/blue] [cyan]{item}[/cyan]"
+                            )
                 else:
                     lines.append(
                         f"{indent}[blue]└──[/blue] [cyan]{key} : [/cyan]{value}"

--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -60,12 +60,104 @@ def test_apply_plan_adds_to_memory(monkeypatch):
 
     assert resp == fake_response
 
-    assert {
-        "tool": "foo",
-        "argument": "bar",
-    } in agent.memory.step_content.values() or agent.memory.step_content == {
-        "tool": "foo",
-        "argument": "bar",
+    action_content = agent.memory.step_content.get("action")
+    assert action_content is not None
+    assert "tool_calls" in action_content
+    assert len(action_content["tool_calls"]) == 1
+    assert action_content["tool_calls"][0] == {"tool": "foo", "argument": "bar"}
+
+def test_apply_plan_preserves_multiple_tool_calls(monkeypatch):
+    """All tool call results must be preserved when the LLM returns >1 tool call."""
+    monkeypatch.setenv("GEMINI_API_KEY", "dummy")
+
+    class DummyModel(Model):
+        def __init__(self):
+            super().__init__(seed=42)
+            self.grid = MultiGrid(5, 5, torus=False)
+
+    model = DummyModel()
+    agent = LLMAgent.create_agents(
+        model,
+        n=1,
+        reasoning=ReActReasoning,
+        system_prompt="test",
+        vision=-1,
+        internal_state=["test_state"],
+    ).to_list()[0]
+    model.grid.place_agent(agent, (1, 1))
+    agent.memory = ShortTermMemory(agent=agent, n=5, display=False)
+
+    fake_response = [
+        {"tool_call_id": "1", "role": "tool", "name": "move_one_step", "response": "agent moved to (3, 4)"},
+        {"tool_call_id": "2", "role": "tool", "name": "arrest_citizen", "response": "Citizen 12 arrested"},
+    ]
+    monkeypatch.setattr(
+        agent.tool_manager, "call_tools", lambda agent, llm_response: fake_response
+    )
+
+    plan = Plan(step=0, llm_plan="do something")
+    agent.apply_plan(plan)
+
+    action_content = agent.memory.step_content.get("action")
+    assert action_content is not None
+    assert "tool_calls" in action_content
+    assert len(action_content["tool_calls"]) == 2
+    assert action_content["tool_calls"][0] == {
+        "name": "move_one_step",
+        "response": "agent moved to (3, 4)",
+    }
+    assert action_content["tool_calls"][1] == {
+        "name": "arrest_citizen",
+        "response": "Citizen 12 arrested",
+    }
+
+
+@pytest.mark.asyncio
+async def test_aapply_plan_preserves_multiple_tool_calls(monkeypatch):
+    """Async variant: all tool call results must be preserved."""
+    monkeypatch.setenv("GEMINI_API_KEY", "dummy")
+
+    class DummyModel(Model):
+        def __init__(self):
+            super().__init__(seed=42)
+            self.grid = MultiGrid(5, 5, torus=False)
+
+    model = DummyModel()
+    agent = LLMAgent.create_agents(
+        model,
+        n=1,
+        reasoning=ReActReasoning,
+        system_prompt="test",
+        vision=-1,
+        internal_state=["test_state"],
+    ).to_list()[0]
+    model.grid.place_agent(agent, (1, 1))
+    agent.memory = ShortTermMemory(agent=agent, n=5, display=False)
+
+    fake_response = [
+        {"tool_call_id": "1", "role": "tool", "name": "move_one_step", "response": "agent moved to (3, 4)"},
+        {"tool_call_id": "2", "role": "tool", "name": "arrest_citizen", "response": "Citizen 12 arrested"},
+    ]
+
+    async def fake_acall_tools(agent, llm_response):
+        return fake_response
+
+    monkeypatch.setattr(agent.tool_manager, "acall_tools", fake_acall_tools)
+
+    plan = Plan(step=0, llm_plan="do something")
+    await agent.aapply_plan(plan)
+
+    action_content = agent.memory.step_content.get("action")
+    assert action_content is not None
+    assert "tool_calls" in action_content
+    assert len(action_content["tool_calls"]) == 2
+    assert action_content["tool_calls"][0] == {
+        "name": "move_one_step",
+        "response": "agent moved to (3, 4)",
+    }
+    assert action_content["tool_calls"][1] == {
+        "name": "arrest_citizen",
+        "response": "Citizen 12 arrested",
     }
 
 

--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -66,6 +66,7 @@ def test_apply_plan_adds_to_memory(monkeypatch):
     assert len(action_content["tool_calls"]) == 1
     assert action_content["tool_calls"][0] == {"tool": "foo", "argument": "bar"}
 
+
 def test_apply_plan_preserves_multiple_tool_calls(monkeypatch):
     """All tool call results must be preserved when the LLM returns >1 tool call."""
     monkeypatch.setenv("GEMINI_API_KEY", "dummy")
@@ -88,8 +89,18 @@ def test_apply_plan_preserves_multiple_tool_calls(monkeypatch):
     agent.memory = ShortTermMemory(agent=agent, n=5, display=False)
 
     fake_response = [
-        {"tool_call_id": "1", "role": "tool", "name": "move_one_step", "response": "agent moved to (3, 4)"},
-        {"tool_call_id": "2", "role": "tool", "name": "arrest_citizen", "response": "Citizen 12 arrested"},
+        {
+            "tool_call_id": "1",
+            "role": "tool",
+            "name": "move_one_step",
+            "response": "agent moved to (3, 4)",
+        },
+        {
+            "tool_call_id": "2",
+            "role": "tool",
+            "name": "arrest_citizen",
+            "response": "Citizen 12 arrested",
+        },
     ]
     monkeypatch.setattr(
         agent.tool_manager, "call_tools", lambda agent, llm_response: fake_response
@@ -135,8 +146,18 @@ async def test_aapply_plan_preserves_multiple_tool_calls(monkeypatch):
     agent.memory = ShortTermMemory(agent=agent, n=5, display=False)
 
     fake_response = [
-        {"tool_call_id": "1", "role": "tool", "name": "move_one_step", "response": "agent moved to (3, 4)"},
-        {"tool_call_id": "2", "role": "tool", "name": "arrest_citizen", "response": "Citizen 12 arrested"},
+        {
+            "tool_call_id": "1",
+            "role": "tool",
+            "name": "move_one_step",
+            "response": "agent moved to (3, 4)",
+        },
+        {
+            "tool_call_id": "2",
+            "role": "tool",
+            "name": "arrest_citizen",
+            "response": "Citizen 12 arrested",
+        },
     ]
 
     async def fake_acall_tools(agent, llm_response):

--- a/tests/test_memory/test_memory_parent.py
+++ b/tests/test_memory/test_memory_parent.py
@@ -60,6 +60,22 @@ class TestMemoryEntry:
         assert "alpha" in str_repr
         assert "beta" in str_repr
 
+    def test_memory_entry_str_with_nested_tool_calls_list(self):
+        """Test MemoryEntry string representation with nested tool_calls list under action."""
+        mock_agent = Mock()
+        content = {
+            "action": {
+                "tool_calls": [
+                    {"name": "move_one_step", "response": "moved"},
+                    {"name": "arrest_citizen", "response": "arrested"},
+                ]
+            }
+        }
+        entry = MemoryEntry(content=content, step=1, agent=mock_agent)
+        str_repr = str(entry)
+        assert "move_one_step" in str_repr
+        assert "arrest_citizen" in str_repr
+
 
 class MemoryMock(Memory):
     def __init__(

--- a/tests/test_memory/test_memory_parent.py
+++ b/tests/test_memory/test_memory_parent.py
@@ -37,6 +37,29 @@ class TestMemoryEntry:
         assert "Test content" in str_repr
         assert "observation" in str_repr
 
+    def test_memory_entry_str_with_list_of_dicts(self):
+        """Test MemoryEntry string representation with list values (e.g. tool_calls)."""
+        mock_agent = Mock()
+        content = {
+            "action": [
+                {"name": "move_one_step", "response": "moved"},
+                {"name": "arrest_citizen", "response": "arrested"},
+            ]
+        }
+        entry = MemoryEntry(content=content, step=1, agent=mock_agent)
+        str_repr = str(entry)
+        assert "move_one_step" in str_repr
+        assert "arrest_citizen" in str_repr
+
+    def test_memory_entry_str_with_list_of_strings(self):
+        """Test MemoryEntry string representation with a list of plain strings."""
+        mock_agent = Mock()
+        content = {"tags": ["alpha", "beta"]}
+        entry = MemoryEntry(content=content, step=1, agent=mock_agent)
+        str_repr = str(entry)
+        assert "alpha" in str_repr
+        assert "beta" in str_repr
+
 
 class MemoryMock(Memory):
     def __init__(


### PR DESCRIPTION
### Summary

`apply_plan()` and `aapply_plan()` flatten multiple tool call results into a single dict, causing all but the last result to be silently lost.

### Bug / Issue

Fixes #142

Each tool result has the same keys (`name`, `response`), so the flat dict comprehension overwrites earlier entries. If the LLM calls both `move_one_step` and `arrest_citizen`, only the arrest is stored in memory.

### Implementation

- **`mesa_llm/llm_agent.py`** — Replaced the flat dict comprehension in `apply_plan()` and `aapply_plan()` with a `"tool_calls"` list that preserves all results.
- **`mesa_llm/memory/memory.py`** — Added `list` handling to `MemoryEntry.__str__()` so the new structure renders correctly.
- **`tests/test_llm_agent.py`** — Updated existing test assertion; added `test_apply_plan_preserves_multiple_tool_calls` (sync) and `test_aapply_plan_preserves_multiple_tool_calls` (async).

### Testing

```
tests/test_llm_agent.py  — 17 passed 
tests/test_memory/       — 40 passed 
```