### PR TITLE
fix: store unique_ids instead of Agent objects in send_message memory…

### DIFF
--- a/mesa_llm/llm_agent.py
+++ b/mesa_llm/llm_agent.py
@@ -267,8 +267,8 @@ class LLMAgent(Agent):
                 type="message",
                 content={
                     "message": message,
-                    "sender": self,
-                    "recipients": recipients,
+                    "sender": self.unique_id,
+                    "recipients": [r.unique_id for r in recipients],
                 },
             )
 
@@ -283,8 +283,8 @@ class LLMAgent(Agent):
                 type="message",
                 content={
                     "message": message,
-                    "sender": self,
-                    "recipients": recipients,
+                    "sender": self.unique_id,
+                    "recipients": [r.unique_id for r in recipients],
                 },
             )
 

--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -1,5 +1,6 @@
 # tests/test_llm_agent.py
 
+import json
 import re
 
 import pytest
@@ -612,3 +613,94 @@ def test_generate_obs_orthogonal_grid_branches(monkeypatch):
     obs = agent.generate_obs()
 
     assert len(obs.local_state) == 0
+
+
+# ---------------------------------------------------------------------------
+# send_message / asend_message – store unique_ids, not Agent objects (#156)
+# ---------------------------------------------------------------------------
+
+
+def _make_send_message_model(monkeypatch):
+    """Shared setup: two-agent MultiGrid model with ShortTermMemory."""
+    monkeypatch.setenv("GEMINI_API_KEY", "dummy")
+
+    class DummyModel(Model):
+        def __init__(self):
+            super().__init__(seed=45)
+            self.grid = MultiGrid(3, 3, torus=False)
+
+        def add_agent(self, pos):
+            agents = LLMAgent.create_agents(
+                self,
+                n=1,
+                reasoning=lambda agent: None,
+                system_prompt="Test",
+                vision=-1,
+                internal_state=[],
+            )
+            agent = agents.to_list()[0]
+            self.grid.place_agent(agent, pos)
+            return agent
+
+    model = DummyModel()
+
+    sender = model.add_agent((0, 0))
+    sender.memory = ShortTermMemory(agent=sender, n=5, display=True)
+    sender.unique_id = 10
+
+    recipient = model.add_agent((1, 1))
+    recipient.memory = ShortTermMemory(agent=recipient, n=5, display=True)
+    recipient.unique_id = 20
+
+    return sender, recipient
+
+
+def test_send_message_stores_serializable_ids(monkeypatch):
+    """send_message stores sender/recipients as unique_ids, not Agent objects."""
+    sender, recipient = _make_send_message_model(monkeypatch)
+
+    captured = {}
+
+    def capture_content(type, content):
+        captured.update(content)
+
+    monkeypatch.setattr(recipient.memory, "add_to_memory", capture_content)
+    monkeypatch.setattr(sender.memory, "add_to_memory", lambda *a, **kw: None)
+
+    sender.send_message("hello", recipients=[recipient])
+
+    assert captured["sender"] == 10
+    assert captured["recipients"] == [20]
+    assert captured["message"] == "hello"
+
+    # Must not raise TypeError when serializing
+    data = json.loads(json.dumps(captured))
+    assert data["sender"] == 10
+    assert data["recipients"] == [20]
+
+
+@pytest.mark.asyncio
+async def test_asend_message_stores_serializable_ids(monkeypatch):
+    """asend_message stores sender/recipients as unique_ids, not Agent objects."""
+    sender, recipient = _make_send_message_model(monkeypatch)
+
+    captured = {}
+
+    async def capture_content(type, content):
+        captured.update(content)
+
+    async def noop(*a, **kw):
+        pass
+
+    monkeypatch.setattr(recipient.memory, "aadd_to_memory", capture_content)
+    monkeypatch.setattr(sender.memory, "aadd_to_memory", noop)
+
+    await sender.asend_message("hello", recipients=[recipient])
+
+    assert captured["sender"] == 10
+    assert captured["recipients"] == [20]
+    assert captured["message"] == "hello"
+
+    data = json.loads(json.dumps(captured))
+    assert data["sender"] == 10
+    assert data["recipients"] == [20]

--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -616,7 +616,7 @@ def test_generate_obs_orthogonal_grid_branches(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# send_message / asend_message – store unique_ids, not Agent objects (#156)
+# send_message / asend_message - store unique_ids, not Agent objects (#156)
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Fixes #156

## Description
LLMAgent.send_message and LLMAgent.asend_message were storing Agent objects
(`self` and `recipients`) inside the memory content dictionary.

Agent objects are not JSON serializable, which causes a crash when recorded
events are written to JSON (e.g. when using `SimulationRecorder` or
`model.save_recording()`).

This change replaces Agent objects with their identifiers:

- `sender` → `self.unique_id`
- `recipients` → `[r.unique_id for r in recipients]`

This aligns the behavior with the existing `speak_to` tool, which already
stores identifiers instead of Agent objects.

## Changes
- Updated `send_message` and `asend_message` in `mesa_llm/llm_agent.py`
- Replaced Agent objects with `unique_id` values
- Added tests verifying:
  - sender and recipients are stored as IDs
  - memory content is JSON serializable
  - both sync and async message paths behave correctly

## Testing
- Added new tests in `tests/test_llm_agent.py`
- Ran `pytest` locally: all tests pass

## Checklist
- [x] Tests added/updated
- [x] Existing tests pass
- [x] Fix is minimal and scoped
