### PR TITLE
fix: consolidate evicted entries into long-term memory

### DIFF
--- a/mesa_llm/memory/st_lt_memory.py
+++ b/mesa_llm/memory/st_lt_memory.py
@@ -75,42 +75,56 @@ class STLTMemory(Memory):
 
         self.llm.system_prompt = self.system_prompt
 
-    def _build_consolidation_prompt(self) -> str:
+    def _build_consolidation_prompt(self, evicted_entries: list[MemoryEntry]) -> str:
         """
-        Prompt builder function to reduce redundancy
-        """
-        return f"""
-            Short term memory:
-                {self.format_short_term()}
-            Long term memory:
-                {self.long_term_memory}
-        """
+        Build a prompt that asks the LLM to integrate *evicted* memories
+        into the existing long-term summary.
 
-    def _update_long_term_memory(self):
+        Args:
+            evicted_entries: the oldest short-term entries that were just
+                removed from the deque and need to be summarized.
         """
-        Update the long term memory by summarizing the short term memory with a LLM
+        evicted_text = "\n".join(
+            f"Step {e.step}: \n{e.content}" for e in evicted_entries
+        )
+        return (
+            "Memories to consolidate (oldest entries being removed "
+            "from short-term memory):\n"
+            f"{evicted_text}\n\n"
+            f"Existing long term memory:\n{self.long_term_memory}\n\n"
+            "Please integrate the above memories into a concise, updated "
+            "long-term memory summary."
+        )
+
+    def _update_long_term_memory(self, evicted_entries: list[MemoryEntry]):
         """
-        prompt = self._build_consolidation_prompt()
+        Update the long term memory by summarizing the evicted entries
+        """
+        prompt = self._build_consolidation_prompt(evicted_entries)
         response = self.llm.generate(prompt)
         self.long_term_memory = response.choices[0].message.content
 
-    async def _aupdate_long_term_memory(self):
+    async def _aupdate_long_term_memory(self, evicted_entries: list[MemoryEntry]):
         """
-        Async Function to update long term memory
+        Async version of _update_long_term_memory
         """
-        prompt = self._build_consolidation_prompt()
+        prompt = self._build_consolidation_prompt(evicted_entries)
         response = await self.llm.agenerate(prompt)
         self.long_term_memory = response.choices[0].message.content
 
     def _process_step_core(self, pre_step: bool):
         """
-        Shared core logic for process_step and aprocess_step
+        Shared core logic for process_step and aprocess_step.
+
         Update short-term memory and decide if consolidation is needed.
+        When entries are evicted for consolidation they are captured and
+        returned so the caller can pass them to the LLM for summarization.
 
         Returns:
-            "(new_entry, should_consolidate)"
+            ``(new_entry, evicted_entries)`` where *evicted_entries* is a
+            (possibly empty) list of MemoryEntry objects that were removed
+            from short-term memory and should be consolidated.
         """
-        # Add the new entry to the short term memory
         if pre_step:
             new_entry = MemoryEntry(
                 agent=self.agent,
@@ -119,9 +133,11 @@ class STLTMemory(Memory):
             )
             self.short_term_memory.append(new_entry)
             self.step_content = {}
-            return None, False
+            return None, []
+
         if not self.short_term_memory or self.short_term_memory[-1].step is not None:
-            return None, False
+            return None, []
+
         pre_step_entry = self.short_term_memory.pop()
         self.step_content.update(pre_step_entry.content)
         new_entry = MemoryEntry(
@@ -129,35 +145,38 @@ class STLTMemory(Memory):
             content=self.step_content,
             step=self.agent.model.steps,
         )
-
         self.short_term_memory.append(new_entry)
         self.step_content = {}
 
-        should_consolidate = False
+        evicted: list[MemoryEntry] = []
+
         if (
             len(self.short_term_memory)
             > self.capacity + (self.consolidation_capacity or 0)
             and self.consolidation_capacity
         ):
-            self.short_term_memory.popleft()
-            should_consolidate = True
+            # Pop consolidation_capacity oldest entries for summarization
+            for _ in range(self.consolidation_capacity):
+                if self.short_term_memory:
+                    evicted.append(self.short_term_memory.popleft())
 
         elif (
             len(self.short_term_memory) > self.capacity
             and not self.consolidation_capacity
         ):
+            # No consolidation configured — just discard the oldest entry
             self.short_term_memory.popleft()
 
-        return new_entry, should_consolidate
+        return new_entry, evicted
 
     def process_step(self, pre_step: bool = False):
         """
         Synchronous memory step handler
         """
-        new_entry, should_consolidate = self._process_step_core(pre_step)
+        new_entry, evicted = self._process_step_core(pre_step)
 
-        if should_consolidate:
-            self._update_long_term_memory()
+        if evicted:
+            self._update_long_term_memory(evicted)
 
         if new_entry and self.display:
             new_entry.display()
@@ -166,10 +185,10 @@ class STLTMemory(Memory):
         """
         Async memory step handler (non-blocking consolidation)
         """
-        new_entry, should_consolidate = self._process_step_core(pre_step)
+        new_entry, evicted = self._process_step_core(pre_step)
 
-        if should_consolidate:
-            await self._aupdate_long_term_memory()
+        if evicted:
+            await self._aupdate_long_term_memory(evicted)
 
         if new_entry and self.display:
             new_entry.display()

--- a/tests/test_memory/test_STLT_memory.py
+++ b/tests/test_memory/test_STLT_memory.py
@@ -1,5 +1,7 @@
 from collections import deque
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from mesa_llm.memory.memory import MemoryEntry
 from mesa_llm.memory.st_lt_memory import STLTMemory
@@ -120,11 +122,15 @@ class TestSTLTMemory:
         memory.llm = mock_llm
         memory.long_term_memory = "Previous memory"
 
-        memory._update_long_term_memory()
+        evicted = [
+            MemoryEntry(
+                content={"observation": "old content"}, step=0, agent=mock_agent
+            )
+        ]
+        memory._update_long_term_memory(evicted)
 
         call_args = mock_llm.generate.call_args[0][0]
-        assert "Short term memory:" in call_args
-        assert "Long term memory:" in call_args
+        assert "old content" in call_args
         assert "Previous memory" in call_args
 
         # Must be a plain string, not a ModelResponse object
@@ -145,12 +151,102 @@ class TestSTLTMemory:
         memory = STLTMemory(agent=mock_agent, llm_model="provider/test_model")
         memory.llm = mock_llm
 
-        memory._update_long_term_memory()
+        evicted = [MemoryEntry(content={"data": "evicted"}, step=0, agent=mock_agent)]
+        memory._update_long_term_memory(evicted)
 
         assert isinstance(memory.long_term_memory, str), (
             "long_term_memory must be a string, not a ModelResponse object"
         )
         assert memory.long_term_memory == "This is the summary text"
+
+    def test_consolidation_receives_evicted_entries(
+        self, mock_agent, mock_llm, llm_response_factory
+    ):
+        """Regression test for #107: evicted entries must be passed to the
+        LLM for summarization, not the remaining short-term memories."""
+        mock_llm.generate.return_value = llm_response_factory("Consolidated summary")
+
+        memory = STLTMemory(
+            agent=mock_agent,
+            short_term_capacity=2,
+            consolidation_capacity=2,
+            llm_model="provider/test_model",
+        )
+        memory.llm = mock_llm
+
+        # Fill up: 2 (capacity) + 2 (consolidation) + 1 to trigger
+        with patch("rich.console.Console"):
+            for i in range(5):
+                memory.add_to_memory("observation", {"content": f"step_{i}"})
+                memory.process_step(pre_step=True)
+                mock_agent.model.steps = i + 1
+                memory.process_step(pre_step=False)
+
+        # The LLM should have been called with the evicted entries
+        assert mock_llm.generate.called
+        prompt = mock_llm.generate.call_args[0][0]
+        # The prompt must contain the evicted memories, not just the
+        # remaining ones
+        assert "consolidate" in prompt.lower() or "removed" in prompt.lower()
+
+    @pytest.mark.asyncio
+    async def test_aupdate_long_term_memory(
+        self, mock_agent, mock_llm, llm_response_factory
+    ):
+        """Cover the async consolidation path (_aupdate_long_term_memory)."""
+        mock_llm.agenerate = AsyncMock(
+            return_value=llm_response_factory("Async consolidated summary")
+        )
+
+        memory = STLTMemory(agent=mock_agent, llm_model="provider/test_model")
+        memory.llm = mock_llm
+        memory.long_term_memory = "Old summary"
+
+        evicted = [
+            MemoryEntry(
+                content={"observation": "evicted data"}, step=0, agent=mock_agent
+            )
+        ]
+        await memory._aupdate_long_term_memory(evicted)
+
+        mock_llm.agenerate.assert_called_once()
+        prompt = mock_llm.agenerate.call_args[0][0]
+        assert "evicted data" in prompt
+        assert "Old summary" in prompt
+        assert isinstance(memory.long_term_memory, str)
+        assert memory.long_term_memory == "Async consolidated summary"
+
+    def test_post_step_without_pending_pre_step_is_noop(self, mock_agent):
+        """Calling process_step(pre_step=False) when no pre-step entry is
+        pending must return early without side effects."""
+        memory = STLTMemory(agent=mock_agent, llm_model="provider/test_model")
+        # Inject a finalized entry (step is not None)
+        memory.short_term_memory.append(
+            MemoryEntry(content={"data": "done"}, step=1, agent=mock_agent)
+        )
+        with patch("rich.console.Console"):
+            memory.process_step(pre_step=False)
+        # Memory should be unchanged
+        assert len(memory.short_term_memory) == 1
+        assert memory.short_term_memory[0].step == 1
+
+    def test_overflow_without_consolidation_discards_oldest(self, mock_agent):
+        """When consolidation_capacity=0, exceeding capacity should simply
+        discard the oldest entry without calling the LLM."""
+        memory = STLTMemory(
+            agent=mock_agent,
+            short_term_capacity=2,
+            consolidation_capacity=0,
+            llm_model="provider/test_model",
+        )
+        with patch("rich.console.Console"):
+            for i in range(4):
+                memory.add_to_memory("observation", {"content": f"step_{i}"})
+                memory.process_step(pre_step=True)
+                mock_agent.model.steps = i + 1
+                memory.process_step(pre_step=False)
+        # Capacity is 2, no consolidation, so only 2 entries should remain
+        assert len(memory.short_term_memory) <= 2
 
     def test_observation_tracking(self, mock_agent):
         """Test that observations are properly tracked and only changes stored"""

--- a/tests/test_memory/test_STLT_memory.py
+++ b/tests/test_memory/test_STLT_memory.py
@@ -248,6 +248,42 @@ class TestSTLTMemory:
         # Capacity is 2, no consolidation, so only 2 entries should remain
         assert len(memory.short_term_memory) <= 2
 
+    def test_consolidation_stops_when_deque_exhausted(
+        self, mock_agent, mock_llm, llm_response_factory
+    ):
+        """The guard `if self.short_term_memory` inside the eviction loop
+        prevents popping from an empty deque.  Exercise it by forcing
+        consolidation_capacity to exceed the actual deque size."""
+        mock_llm.generate.return_value = llm_response_factory("Summary")
+
+        memory = STLTMemory(
+            agent=mock_agent,
+            short_term_capacity=1,
+            consolidation_capacity=5,
+            llm_model="provider/test_model",
+        )
+        memory.llm = mock_llm
+
+        # Seed the deque with one finalized entry and one pending entry
+        memory.short_term_memory.append(
+            MemoryEntry(content={"data": "old"}, step=0, agent=mock_agent)
+        )
+        memory.short_term_memory.append(
+            MemoryEntry(content={"data": "pending"}, step=None, agent=mock_agent)
+        )
+        # Force the consolidation condition to trigger despite the small
+        # deque (2 entries).  After process_step merges the pending entry
+        # the deque still has 2, but the loop tries to pop 5 — the guard
+        # stops it after 2.
+        memory.capacity = -100
+
+        with patch("rich.console.Console"):
+            memory.process_step(pre_step=False)
+
+        # Consolidation was called with the 2 entries that were available
+        assert mock_llm.generate.called
+        assert len(memory.short_term_memory) == 0
+
     def test_observation_tracking(self, mock_agent):
         """Test that observations are properly tracked and only changes stored"""
         memory = STLTMemory(agent=mock_agent, llm_model="provider/test_model")


### PR DESCRIPTION
## Summary
Fixes #107

`STLTMemory._process_step_core()` discards popped short-term entries without passing them to the LLM for summarization. Instead, `_build_consolidation_prompt()` formats the **remaining** active short-term memories — so the LLM redundantly summarizes memories that are still in short-term, while the evicted ones are permanently lost.

### Root Cause
1. `self.short_term_memory.popleft()` discards the entry (return value is ignored)
2. Only **one** entry is popped even when `consolidation_capacity` could be > 1
3. `_build_consolidation_prompt()` sends the remaining short-term memories to the LLM — the evicted entries are never seen

### Changes

- **`_process_step_core()`**: Now captures all evicted entries (up to `consolidation_capacity`) in a list and returns them alongside the new entry
- **`_build_consolidation_prompt(evicted_entries)`**: Accepts the evicted entries and constructs a prompt asking the LLM to integrate them into the existing long-term summary
- **`_update_long_term_memory(evicted_entries)` / `_aupdate_long_term_memory(evicted_entries)`**: Updated signatures to receive and forward evicted entries
- **`process_step()` / `aprocess_step()`**: Pass evicted entries to the consolidation methods
- **Tests**: Updated existing `test_update_long_term_memory` and `test_long_term_memory_stores_string_not_response_object` to match new signatures; added `test_consolidation_receives_evicted_entries` regression test

### Before vs After

| | Before | After |
|---|---|---|
| Evicted entries | Discarded silently | Captured and passed to LLM |
| LLM receives | Remaining short-term memories | Evicted entries + existing long-term summary |
| Entries popped per trigger | Always 1 | `consolidation_capacity` entries |

### Test Plan
- [x] All 263 existing tests pass
- [x] 1 new regression test for consolidation behavior
- [x] Pre-commit hooks pass (ruff, codespell)