### PR TITLE
fix: render readable text in get_communication_history for all memory…

### DIFF
--- a/mesa_llm/memory/episodic_memory.py
+++ b/mesa_llm/memory/episodic_memory.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
-from mesa_llm.memory.memory import Memory, MemoryEntry
+from mesa_llm.memory.memory import Memory, MemoryEntry, _format_message_entry
 
 if TYPE_CHECKING:
     from mesa_llm.llm_agent import LLMAgent
@@ -259,7 +259,7 @@ class EpisodicMemory(Memory):
         """
         return "\n".join(
             [
-                f"step {entry.step}: {entry.content['message']}\n\n"
+                f"step {entry.step}: {_format_message_entry(entry.content['message'])}\n\n"
                 for entry in self.memory_entries
                 if "message" in entry.content
             ]

--- a/mesa_llm/memory/memory.py
+++ b/mesa_llm/memory/memory.py
@@ -11,6 +11,22 @@ if TYPE_CHECKING:
     from mesa_llm.llm_agent import LLMAgent
 
 
+def _format_message_entry(msg_value) -> str:
+    """Render a message memory value as a readable string.
+
+    Handles the nested dict produced by the speak_to tool:
+        {"message": "<text>", "sender": <id>, "recipients": [...]}
+    as well as plain strings stored by legacy or test code.
+    """
+    if isinstance(msg_value, dict):
+        text = msg_value.get("message", str(msg_value))
+        sender = msg_value.get("sender")
+        if sender is not None:
+            return f"Agent {sender} says: {text}"
+        return str(text)
+    return str(msg_value)
+
+
 @dataclass
 class MemoryEntry:
     """

--- a/mesa_llm/memory/st_lt_memory.py
+++ b/mesa_llm/memory/st_lt_memory.py
@@ -1,7 +1,7 @@
 from collections import deque
 from typing import TYPE_CHECKING
 
-from mesa_llm.memory.memory import Memory, MemoryEntry
+from mesa_llm.memory.memory import Memory, MemoryEntry, _format_message_entry
 
 if TYPE_CHECKING:
     from mesa_llm.llm_agent import LLMAgent
@@ -226,7 +226,7 @@ class STLTMemory(Memory):
         """
         return "\n".join(
             [
-                f"step {entry.step}: {entry.content['message']}\n\n"
+                f"step {entry.step}: {_format_message_entry(entry.content['message'])}\n\n"
                 for entry in self.short_term_memory
                 if "message" in entry.content
             ]

--- a/mesa_llm/memory/st_memory.py
+++ b/mesa_llm/memory/st_memory.py
@@ -1,7 +1,7 @@
 from collections import deque
 from typing import TYPE_CHECKING
 
-from mesa_llm.memory.memory import Memory, MemoryEntry
+from mesa_llm.memory.memory import Memory, MemoryEntry, _format_message_entry
 
 if TYPE_CHECKING:
     from mesa_llm.llm_agent import LLMAgent
@@ -100,7 +100,7 @@ class ShortTermMemory(Memory):
         """
         return "\n".join(
             [
-                f"step {entry.step}: {entry.content['message']}\n\n"
+                f"step {entry.step}: {_format_message_entry(entry.content['message'])}\n\n"
                 for entry in self.short_term_memory
                 if "message" in entry.content
             ]

--- a/tests/test_memory/test_STLT_memory.py
+++ b/tests/test_memory/test_STLT_memory.py
@@ -349,7 +349,13 @@ class TestSTLTMemory:
         memory = STLTMemory(agent=mock_agent, llm_model="provider/test_model")
 
         entry = MemoryEntry(
-            content={"message": {"message": "regroup at base", "sender": 3, "recipients": [1, 2]}},
+            content={
+                "message": {
+                    "message": "regroup at base",
+                    "sender": 3,
+                    "recipients": [1, 2],
+                }
+            },
             step=10,
             agent=mock_agent,
         )
@@ -371,7 +377,9 @@ class TestSTLTMemory:
             agent=mock_agent,
         )
         entry_msg = MemoryEntry(
-            content={"message": {"message": "all clear", "sender": 9, "recipients": []}},
+            content={
+                "message": {"message": "all clear", "sender": 9, "recipients": []}
+            },
             step=2,
             agent=mock_agent,
         )
@@ -382,7 +390,9 @@ class TestSTLTMemory:
         assert "all clear" in history
         assert "position" not in history
 
-    def test_get_communication_history_returns_empty_string_when_no_messages(self, mock_agent):
+    def test_get_communication_history_returns_empty_string_when_no_messages(
+        self, mock_agent
+    ):
         """Returns an empty string when short-term memory has no message entries."""
         memory = STLTMemory(agent=mock_agent, llm_model="provider/test_model")
 

--- a/tests/test_memory/test_STLT_memory.py
+++ b/tests/test_memory/test_STLT_memory.py
@@ -332,3 +332,65 @@ class TestSTLTMemory:
         )
         assert "Short term memory:" in result
         assert "Long term memory:" in result
+
+    def test_get_communication_history_nested_dict(self, mock_agent):
+        """
+        Regression test: get_communication_history must produce readable text when
+        the message entry is a nested dict (produced by speak_to).
+
+        speak_to calls:
+            add_to_memory(type="message", content={"message": <text>, "sender": <id>, ...})
+
+        Memory.add_to_memory stores the content dict under step_content["message"], so:
+            entry.content = {"message": {"message": <text>, "sender": <id>, "recipients": [...]}}
+
+        The fixed code must render "Agent <id> says: <text>", not a raw dict.
+        """
+        memory = STLTMemory(agent=mock_agent, llm_model="provider/test_model")
+
+        entry = MemoryEntry(
+            content={"message": {"message": "regroup at base", "sender": 3, "recipients": [1, 2]}},
+            step=10,
+            agent=mock_agent,
+        )
+        memory.short_term_memory.append(entry)
+
+        history = memory.get_communication_history()
+
+        assert "Agent 3 says: regroup at base" in history
+        assert "step 10" in history
+        assert "{'message'" not in history
+
+    def test_get_communication_history_skips_non_message_entries(self, mock_agent):
+        """Entries without a top-level 'message' key are excluded from communication history."""
+        memory = STLTMemory(agent=mock_agent, llm_model="provider/test_model")
+
+        entry_obs = MemoryEntry(
+            content={"observation": {"position": (0, 0)}},
+            step=1,
+            agent=mock_agent,
+        )
+        entry_msg = MemoryEntry(
+            content={"message": {"message": "all clear", "sender": 9, "recipients": []}},
+            step=2,
+            agent=mock_agent,
+        )
+        memory.short_term_memory.extend([entry_obs, entry_msg])
+
+        history = memory.get_communication_history()
+
+        assert "all clear" in history
+        assert "position" not in history
+
+    def test_get_communication_history_returns_empty_string_when_no_messages(self, mock_agent):
+        """Returns an empty string when short-term memory has no message entries."""
+        memory = STLTMemory(agent=mock_agent, llm_model="provider/test_model")
+
+        entry = MemoryEntry(
+            content={"observation": {"data": "nothing to say"}},
+            step=1,
+            agent=mock_agent,
+        )
+        memory.short_term_memory.append(entry)
+
+        assert memory.get_communication_history() == ""

--- a/tests/test_memory/test_episodic_memory.py
+++ b/tests/test_memory/test_episodic_memory.py
@@ -353,7 +353,13 @@ class TestEpisodicMemory:
 
         # Simulate what _finalize_entry produces after speak_to + importance grading
         entry = MemoryEntry(
-            content={"message": {"message": "meet me at the north", "sender": 7, "importance": 3}},
+            content={
+                "message": {
+                    "message": "meet me at the north",
+                    "sender": 7,
+                    "importance": 3,
+                }
+            },
             step=5,
             agent=episodic_mock_agent,
         )
@@ -366,7 +372,9 @@ class TestEpisodicMemory:
         # Must not expose raw dict representation
         assert "{'message'" not in history
 
-    def test_get_communication_history_skips_non_message_entries(self, episodic_mock_agent):
+    def test_get_communication_history_skips_non_message_entries(
+        self, episodic_mock_agent
+    ):
         """Entries without a 'message' key must not appear in communication history."""
         memory = EpisodicMemory(
             agent=episodic_mock_agent, llm_model="provider/test_model"

--- a/tests/test_memory/test_episodic_memory.py
+++ b/tests/test_memory/test_episodic_memory.py
@@ -333,6 +333,62 @@ class TestEpisodicMemory:
             "No message here" not in history
         )  # step 2  does not have message field thus it must not be present in the returned string
 
+    def test_get_communication_history_nested_dict(self, episodic_mock_agent):
+        """
+        Regression test: get_communication_history must render readable text when
+        the message entry is a nested dict (the real structure produced by speak_to).
+
+        speak_to stores:
+            add_to_memory(type="message", content={"message": <text>, "sender": <id>, ...})
+
+        EpisodicMemory._finalize_entry wraps this under the type key, so:
+            entry.content = {"message": {"message": <text>, "sender": <id>, "importance": N}}
+
+        The old code rendered the raw dict; the fixed code must produce
+        "Agent <id> says: <text>".
+        """
+        memory = EpisodicMemory(
+            agent=episodic_mock_agent, llm_model="provider/test_model"
+        )
+
+        # Simulate what _finalize_entry produces after speak_to + importance grading
+        entry = MemoryEntry(
+            content={"message": {"message": "meet me at the north", "sender": 7, "importance": 3}},
+            step=5,
+            agent=episodic_mock_agent,
+        )
+        memory.memory_entries.append(entry)
+
+        history = memory.get_communication_history()
+
+        assert "Agent 7 says: meet me at the north" in history
+        assert "step 5" in history
+        # Must not expose raw dict representation
+        assert "{'message'" not in history
+
+    def test_get_communication_history_skips_non_message_entries(self, episodic_mock_agent):
+        """Entries without a 'message' key must not appear in communication history."""
+        memory = EpisodicMemory(
+            agent=episodic_mock_agent, llm_model="provider/test_model"
+        )
+
+        entry_obs = MemoryEntry(
+            content={"observation": {"position": (1, 1), "importance": 2}},
+            step=3,
+            agent=episodic_mock_agent,
+        )
+        entry_msg = MemoryEntry(
+            content={"message": {"message": "hello", "sender": 1, "importance": 2}},
+            step=4,
+            agent=episodic_mock_agent,
+        )
+        memory.memory_entries.extend([entry_obs, entry_msg])
+
+        history = memory.get_communication_history()
+
+        assert "hello" in history
+        assert "position" not in history
+
     def test_retrieve_empty_memory(self, mock_agent):
         """
         Function to verify empty list is returned when retrieval of memory is empty

--- a/tests/test_memory/test_memory_parent.py
+++ b/tests/test_memory/test_memory_parent.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from mesa_llm.memory.memory import Memory, MemoryEntry
+from mesa_llm.memory.memory import Memory, MemoryEntry, _format_message_entry
 from mesa_llm.module_llm import ModuleLLM
 
 if TYPE_CHECKING:
@@ -149,3 +149,31 @@ class TestMemoryParent:
             str(exc_info.value)
             == "Expected 'content' to be dict, got str: 'raw async string plan'"
         )
+
+
+class TestFormatMessageEntry:
+    """Unit tests for the _format_message_entry helper."""
+
+    def test_plain_string_passthrough(self):
+        """Legacy/test entries that store message as a plain string are returned as-is."""
+        assert _format_message_entry("Hello") == "Hello"
+
+    def test_nested_dict_with_sender(self):
+        """Real speak_to payload: dict with 'message' text and 'sender' id."""
+        msg = {"message": "hello world", "sender": 42, "recipients": [7]}
+        assert _format_message_entry(msg) == "Agent 42 says: hello world"
+
+    def test_nested_dict_without_sender(self):
+        """Dict with message text but no sender — render text only."""
+        msg = {"message": "standalone note"}
+        assert _format_message_entry(msg) == "standalone note"
+
+    def test_nested_dict_without_message_key_falls_back_to_str(self):
+        """Dict lacking 'message' key falls back to str() of the whole dict."""
+        msg = {"foo": "bar"}
+        assert _format_message_entry(msg) == str(msg)
+
+    def test_episodic_payload_with_importance(self):
+        """EpisodicMemory adds 'importance' to the content dict — should still format cleanly."""
+        msg = {"message": "critical update", "sender": 5, "importance": 4}
+        assert _format_message_entry(msg) == "Agent 5 says: critical update"

--- a/tests/test_memory/test_st_memory.py
+++ b/tests/test_memory/test_st_memory.py
@@ -174,7 +174,9 @@ class TestShortTermMemory:
         memory = ShortTermMemory(agent=mock_agent, display=False)
 
         entry = MemoryEntry(
-            content={"message": {"message": "status update", "sender": 12, "recipients": [3]}},
+            content={
+                "message": {"message": "status update", "sender": 12, "recipients": [3]}
+            },
             step=7,
             agent=mock_agent,
         )
@@ -196,7 +198,9 @@ class TestShortTermMemory:
             agent=mock_agent,
         )
         entry_msg = MemoryEntry(
-            content={"message": {"message": "over here", "sender": 2, "recipients": []}},
+            content={
+                "message": {"message": "over here", "sender": 2, "recipients": []}
+            },
             step=2,
             agent=mock_agent,
         )
@@ -207,7 +211,9 @@ class TestShortTermMemory:
         assert "over here" in history
         assert "watching" not in history
 
-    def test_get_communication_history_returns_empty_string_when_no_messages(self, mock_agent):
+    def test_get_communication_history_returns_empty_string_when_no_messages(
+        self, mock_agent
+    ):
         """Returns empty string when no entries contain a 'message' key."""
         memory = ShortTermMemory(agent=mock_agent, display=False)
 

--- a/tests/test_memory/test_st_memory.py
+++ b/tests/test_memory/test_st_memory.py
@@ -157,3 +157,65 @@ class TestShortTermMemory:
         memory.step_content = {"action": "after_step_4"}
         memory.process_step(pre_step=False)
         assert [entry.step for entry in memory.short_term_memory] == [2, 3, 4]
+
+    def test_get_communication_history_nested_dict(self, mock_agent):
+        """
+        Regression test: get_communication_history must produce readable text when
+        the message entry is a nested dict (produced by speak_to).
+
+        speak_to calls:
+            add_to_memory(type="message", content={"message": <text>, "sender": <id>, ...})
+
+        Memory.add_to_memory stores this under step_content["message"], so:
+            entry.content = {"message": {"message": <text>, "sender": <id>, "recipients": [...]}}
+
+        The fixed code must render "Agent <id> says: <text>", not a raw dict.
+        """
+        memory = ShortTermMemory(agent=mock_agent, display=False)
+
+        entry = MemoryEntry(
+            content={"message": {"message": "status update", "sender": 12, "recipients": [3]}},
+            step=7,
+            agent=mock_agent,
+        )
+        memory.short_term_memory.append(entry)
+
+        history = memory.get_communication_history()
+
+        assert "Agent 12 says: status update" in history
+        assert "step 7" in history
+        assert "{'message'" not in history
+
+    def test_get_communication_history_skips_non_message_entries(self, mock_agent):
+        """Entries without a 'message' key are excluded from communication history."""
+        memory = ShortTermMemory(agent=mock_agent, display=False)
+
+        entry_obs = MemoryEntry(
+            content={"observation": "watching"},
+            step=1,
+            agent=mock_agent,
+        )
+        entry_msg = MemoryEntry(
+            content={"message": {"message": "over here", "sender": 2, "recipients": []}},
+            step=2,
+            agent=mock_agent,
+        )
+        memory.short_term_memory.extend([entry_obs, entry_msg])
+
+        history = memory.get_communication_history()
+
+        assert "over here" in history
+        assert "watching" not in history
+
+    def test_get_communication_history_returns_empty_string_when_no_messages(self, mock_agent):
+        """Returns empty string when no entries contain a 'message' key."""
+        memory = ShortTermMemory(agent=mock_agent, display=False)
+
+        entry = MemoryEntry(
+            content={"observation": "nothing happening"},
+            step=1,
+            agent=mock_agent,
+        )
+        memory.short_term_memory.append(entry)
+
+        assert memory.get_communication_history() == ""


### PR DESCRIPTION
Fixes #193

## Summary
- `get_communication_history()` in all three memory classes (`ShortTermMemory`, `STLTMemory`, `EpisodicMemory`) was rendering raw Python dicts instead of readable message strings in the LLM prompt
- Added a shared `_format_message_entry()` helper in `memory.py` that extracts human-readable text from the nested dict structure produced by `speak_to`
- Applied the fix across all three memory implementations and added regression tests

## Root Cause

The `speak_to` tool stores messages as a nested dict:
```python
add_to_memory(
    type="message",
    content={"message": "meet me at the north", "sender": 7, "recipients": [1, 2]},
)
```

This means `entry.content["message"]` is always a dict, not a string. But `get_communication_history()` passed it directly into the f-string:
```python
# Before — renders raw dict
f"step {entry.step}: {entry.content['message']}\n\n"
# Output: step 5: {'message': 'meet me at the north', 'sender': 7, 'recipients': [1, 2]}
```

This garbled output was injected into the ReAct reasoning prompt on every step where agents had exchanged messages, silently corrupting the LLM's view of inter-agent communication.

## Changes

**`mesa_llm/memory/memory.py`**
- Added `_format_message_entry(msg_value) -> str` helper that renders `{"message": "...", "sender": 42, ...}` as `"Agent 42 says: ..."`, with a plain-string passthrough for backward compatibility

**`mesa_llm/memory/episodic_memory.py`, `st_lt_memory.py`, `st_memory.py`**
- Updated `get_communication_history()` in all three to use `_format_message_entry()` instead of raw f-string interpolation

## Tests

- **`TestFormatMessageEntry`** (5 tests) in `test_memory_parent.py` — unit tests for the helper covering: nested dict with sender, without sender, plain string passthrough, missing message key fallback, and EpisodicMemory's importance-augmented payload
- `test_get_communication_history_nested_dict` added to all three memory test files — reproduces the real `speak_to` payload structure and asserts readable output
- `test_get_communication_history_skips_non_message_entries` added to all three — asserts non-message entries are correctly excluded
- `test_get_communication_history_returns_empty_string_when_no_messages` added to `STLTMemory` and `ShortTermMemory`

## Before / After
```python
# Before
step 5: {'message': 'meet me at the north', 'sender': 7, 'recipients': [1, 2]}

# After
step 5: Agent 7 says: meet me at the north
```