### PR TITLE
Fix: SimulationRecorder.save() appends duplicate simulation_end events on repeated calls

### DIFF
--- a/mesa_llm/recording/simulation_recorder.py
+++ b/mesa_llm/recording/simulation_recorder.py
@@ -241,6 +241,9 @@ class SimulationRecorder:
         )
 
         # Record final model state
+        if any(e.event_type == "simulation_end" for e in self.events):
+            return filepath
+
         self.record_model_event(
             event_type="simulation_end",
             content={

--- a/mesa_llm/recording/simulation_recorder.py
+++ b/mesa_llm/recording/simulation_recorder.py
@@ -134,6 +134,15 @@ class SimulationRecorder:
             else:
                 formatted_content = {"data": content}
 
+        # If recording continues after a save/checkpoint, discard the previous
+        # terminal marker so newly recorded events stay chronologically valid.
+        if (
+            event_type != "simulation_end"
+            and self.events
+            and self.events[-1].event_type == "simulation_end"
+        ):
+            self.events.pop()
+
         # Create the event
         event_id = f"{self.simulation_id}_{len(self.events):06d}"
 
@@ -216,6 +225,9 @@ class SimulationRecorder:
 
         filepath = self.output_dir / filename
 
+        if self.events and self.events[-1].event_type == "simulation_end":
+            self.events.pop()
+
         # Update metadata with final state
         self.simulation_metadata.update(
             {
@@ -240,24 +252,31 @@ class SimulationRecorder:
             }
         )
 
-        # Record final model state (only once)
-        if not any(e.event_type == "simulation_end" for e in self.events):
-            self.record_model_event(
-                event_type="simulation_end",
-                content={
-                    "status": (
-                        "unknown"
-                        if getattr(self.model, "max_steps", None) is None
-                        else (
-                            "interrupted"
-                            if self.model.steps < self.model.max_steps
-                            else "completed"
-                        )
-                    ),
-                    "final_step": self.model.steps,
-                    "total_events": len(self.events),
-                },
-            )
+        # Replace the terminal "simulation_end" marker on each save. `save()`
+        # is also used for autosave checkpoints, so the first "simulation_end"
+        # marker must not be frozen forever.
+        simulation_end_event = SimulationEvent(
+            event_id=f"{self.simulation_id}_{len(self.events):06d}",
+            timestamp=datetime.now(UTC),
+            step=self.model.steps,
+            agent_id=None,
+            event_type="simulation_end",
+            content={
+                "status": (
+                    "unknown"
+                    if getattr(self.model, "max_steps", None) is None
+                    else (
+                        "interrupted"
+                        if self.model.steps < self.model.max_steps
+                        else "completed"
+                    )
+                ),
+                "final_step": self.model.steps,
+                "total_events": len(self.events),
+            },
+            metadata={"source": "model"},
+        )
+        self.events.append(simulation_end_event)
 
         # Prepare export data
         export_data = {

--- a/mesa_llm/recording/simulation_recorder.py
+++ b/mesa_llm/recording/simulation_recorder.py
@@ -240,26 +240,24 @@ class SimulationRecorder:
             }
         )
 
-        # Record final model state
-        if any(e.event_type == "simulation_end" for e in self.events):
-            return filepath
-
-        self.record_model_event(
-            event_type="simulation_end",
-            content={
-                "status": (
-                    "unknown"
-                    if getattr(self.model, "max_steps", None) is None
-                    else (
-                        "interrupted"
-                        if self.model.steps < self.model.max_steps
-                        else "completed"
-                    )
-                ),
-                "final_step": self.model.steps,
-                "total_events": len(self.events),
-            },
-        )
+        # Record final model state (only once)
+        if not any(e.event_type == "simulation_end" for e in self.events):
+            self.record_model_event(
+                event_type="simulation_end",
+                content={
+                    "status": (
+                        "unknown"
+                        if getattr(self.model, "max_steps", None) is None
+                        else (
+                            "interrupted"
+                            if self.model.steps < self.model.max_steps
+                            else "completed"
+                        )
+                    ),
+                    "final_step": self.model.steps,
+                    "total_events": len(self.events),
+                },
+            )
 
         # Prepare export data
         export_data = {

--- a/tests/test_recording/test_simulation_recorder.py
+++ b/tests/test_recording/test_simulation_recorder.py
@@ -316,6 +316,48 @@ class TestSimulationRecorder:
         ]
         assert len(simulation_end_events) == 1
 
+        recorded_simulation_end_events = [
+            e for e in recorder.events if e.event_type == "simulation_end"
+        ]
+        assert len(recorded_simulation_end_events) == 1
+        assert recorder.events[-1].event_type == "simulation_end"
+
+    def test_auto_save_checkpoint_does_not_freeze_simulation_end(
+        self, mock_model, temp_dir
+    ):
+        """Autosave checkpoints should not leave stale simulation_end data in later exports."""
+        mock_model.max_steps = 10
+        mock_model.steps = 1
+        recorder = SimulationRecorder(
+            model=mock_model,
+            output_dir=str(temp_dir),
+            auto_save_interval=2,
+        )
+
+        recorder.record_event("early_event_1", {"data": "early_1"})
+        recorder.record_event("early_event_2", {"data": "early_2"})
+        assert recorder.events[-1].event_type == "simulation_end"
+
+        mock_model.steps = 10
+        recorder.record_event("late_event", {"data": "late"})
+        assert all(event.event_type != "simulation_end" for event in recorder.events)
+
+        filepath = recorder.save(filename="final.json", format="json")
+
+        with open(filepath) as f:
+            data = json.load(f)
+
+        event_types = [event["event_type"] for event in data["events"]]
+        assert event_types.count("simulation_end") == 1
+        assert event_types[-1] == "simulation_end"
+
+        simulation_end = data["events"][-1]
+        assert simulation_end["content"]["final_step"] == 10
+        assert simulation_end["content"]["status"] == "completed"
+        assert recorder.events[-1].event_type == "simulation_end"
+        assert recorder.events[-1].content["final_step"] == 10
+        assert recorder.events[-1].content["status"] == "completed"
+
     def test_get_stats(self, recorder, mock_model):
         """Test getting recording statistics."""
         # Add some test events
@@ -338,15 +380,31 @@ class TestSimulationRecorder:
         mock_model.max_steps = 10
         mock_model.steps = 5
 
-        recorder.save()
+        recorder.save(filename="checkpoint.json", format="json")
 
         # Check that completion status is "interrupted" since steps < max_steps
         assert recorder.simulation_metadata["completion_status"] == "interrupted"
 
         # Test completed status
         mock_model.steps = 10
-        recorder.save()
+        filepath = recorder.save(filename="final.json", format="json")
         assert recorder.simulation_metadata["completion_status"] == "completed"
+
+        with open(filepath) as f:
+            data = json.load(f)
+
+        event_types = [event["event_type"] for event in data["events"]]
+        assert event_types.count("simulation_end") == 1
+        assert event_types[-1] == "simulation_end"
+
+        simulation_end_events = [
+            event for event in data["events"] if event["event_type"] == "simulation_end"
+        ]
+        assert simulation_end_events[0]["content"]["status"] == "completed"
+        assert simulation_end_events[0]["content"]["final_step"] == 10
+        assert recorder.events[-1].event_type == "simulation_end"
+        assert recorder.events[-1].content["status"] == "completed"
+        assert recorder.events[-1].content["final_step"] == 10
 
     def test_completion_status_without_max_steps(self, recorder, mock_model):
         """Test completion status when max_steps is not available."""

--- a/tests/test_recording/test_simulation_recorder.py
+++ b/tests/test_recording/test_simulation_recorder.py
@@ -297,6 +297,23 @@ class TestSimulationRecorder:
         with pytest.raises(ValueError, match="Format must be 'json' or 'pickle'"):
             recorder.save(format="xml")
 
+    def test_save_twice_produces_single_simulation_end(self, recorder, temp_dir):
+        """Calling save() twice must not duplicate simulation_end and must write the file both times."""
+        recorder.model.max_steps = 10
+        recorder.record_event("test_event", {"data": "test"})
+
+        filepath1 = recorder.save(filename="test_double_save.json", format="json")
+        filepath2 = recorder.save(filename="test_double_save.json", format="json")
+
+        assert filepath1 == filepath2
+        assert filepath2.exists()
+
+        with open(filepath2) as f:
+            data = json.load(f)
+
+        simulation_end_events = [e for e in data["events"] if e["event_type"] == "simulation_end"]
+        assert len(simulation_end_events) == 1
+
     def test_get_stats(self, recorder, mock_model):
         """Test getting recording statistics."""
         # Add some test events

--- a/tests/test_recording/test_simulation_recorder.py
+++ b/tests/test_recording/test_simulation_recorder.py
@@ -311,7 +311,9 @@ class TestSimulationRecorder:
         with open(filepath2) as f:
             data = json.load(f)
 
-        simulation_end_events = [e for e in data["events"] if e["event_type"] == "simulation_end"]
+        simulation_end_events = [
+            e for e in data["events"] if e["event_type"] == "simulation_end"
+        ]
         assert len(simulation_end_events) == 1
 
     def test_get_stats(self, recorder, mock_model):


### PR DESCRIPTION
### Pre-PR Checklist
- [ T] This PR is a bug fix, not a new feature or enhancement.

### Summary
`SimulationRecorder.save()` called `record_model_event( )` unconditionally every time. A manual `save_recording()` followed by the atexit auto-save produced two `simulation_end` entries in the output file.

### Bug / Issue
Fixes #201 

### Implementation
Added a one-line guard:
```python
if not any(e.event_type == "simulation_end" for e in self.events):
```
so `simulation_end` is written at most once per recorder instance.

### Testing
- All existing recording tests pass: `pytest tests/test_recording/ -v`
- Call `recorder.save()` twice and confirmed only one `simulation_end` entry exists
