### PR TITLE
fix: selected_tools=[] should return no tools, not all tools

### DIFF
--- a/mesa_llm/reasoning/cot.py
+++ b/mesa_llm/reasoning/cot.py
@@ -93,7 +93,12 @@ class CoTReasoning(Reasoning):
         selected_tools: list[str] | None = None,
     ) -> Plan:
         """
-        Plan the next (CoT) action based on the current observation and the agent's memory.
+        Plan the next (CoT) action based on the current observation and memory.
+
+        ``selected_tools`` is forwarded to ``ToolManager.get_all_tools_schema()``.
+        Omitting it or passing ``None`` uses the default behavior of exposing
+        all tools, ``[]`` exposes no tools, and a non-empty list restricts
+        planning/execution to the named tools.
         """
         # If no prompt is provided, use the agent's default step prompt
         if prompt is None:
@@ -155,6 +160,11 @@ class CoTReasoning(Reasoning):
     ) -> Plan:
         """
         Asynchronous version of plan() method for parallel planning.
+
+        ``selected_tools`` follows the same contract as ``plan()``: omitting
+        it or passing ``None`` uses the default behavior of exposing all
+        tools, ``[]`` exposes no tools, and a non-empty list restricts
+        planning/execution to the named tools.
         """
         # If no prompt is provided, use the agent's default step prompt
         if prompt is None:

--- a/mesa_llm/reasoning/react.py
+++ b/mesa_llm/reasoning/react.py
@@ -64,7 +64,12 @@ class ReActReasoning(Reasoning):
         selected_tools: list[str] | None = None,
     ) -> Plan:
         """
-        Plan the next (ReAct) action based on the current observation and the agent's memory.
+        Plan the next (ReAct) action based on the current observation and memory.
+
+        ``selected_tools`` is forwarded to ``ToolManager.get_all_tools_schema()``.
+        Omitting it or passing ``None`` uses the default behavior of exposing
+        all tools, ``[]`` exposes no tools, and a non-empty list restricts
+        planning/execution to the named tools.
         """
 
         if obs is None:
@@ -116,6 +121,11 @@ class ReActReasoning(Reasoning):
     ) -> Plan:
         """
         Asynchronous version of plan() method for parallel planning.
+
+        ``selected_tools`` follows the same contract as ``plan()``: omitting
+        it or passing ``None`` uses the default behavior of exposing all
+        tools, ``[]`` exposes no tools, and a non-empty list restricts
+        planning/execution to the named tools.
         """
         if obs is None:
             obs = await self.agent.agenerate_obs()

--- a/mesa_llm/reasoning/reasoning.py
+++ b/mesa_llm/reasoning/reasoning.py
@@ -84,7 +84,18 @@ class Reasoning(ABC):
         ttl: int = 1,
         selected_tools: list[str] | None = None,
     ) -> Plan:
-        pass
+        """Generate a plan for the next action.
+
+        Args:
+            prompt: Optional prompt override for the reasoning strategy.
+            obs: Optional observation to plan against.
+            ttl: Time-to-live for the generated plan.
+            selected_tools: Optional explicit tool allowlist forwarded to
+                ``ToolManager.get_all_tools_schema()``. If omitted or ``None``,
+                the default behavior exposes all tools. ``[]`` exposes no
+                tools, and a non-empty list restricts planning/execution to
+                the named tools.
+        """
 
     async def aplan(
         self,
@@ -96,6 +107,11 @@ class Reasoning(ABC):
         """
         Asynchronous version of plan() method for parallel planning.
         Default implementation calls the synchronous plan() method.
+
+        ``selected_tools`` follows the same contract as ``plan()``: omitting
+        it or passing ``None`` uses the default behavior of exposing all
+        tools, ``[]`` exposes no tools, and a non-empty list restricts
+        planning/execution to the named tools.
         """
         return self.plan(
             prompt=prompt,
@@ -110,6 +126,13 @@ class Reasoning(ABC):
         selected_tools: list[str] | None = None,
         ttl: int = 1,
     ):
+        """Turn a natural-language plan into tool calls.
+
+        ``selected_tools`` is forwarded to ``ToolManager.get_all_tools_schema()``.
+        Omitting it or passing ``None`` uses the default behavior of exposing
+        all tools, ``[]`` exposes no tools, and a non-empty list restricts
+        execution to the named tools.
+        """
         system_prompt = "You are an executor that executes the plan given to you in the prompt through tool calls."
         self.agent.llm.system_prompt = system_prompt
         rsp = self.agent.llm.generate(
@@ -132,6 +155,11 @@ class Reasoning(ABC):
     ):
         """
         Asynchronous version of execute_tool_call() method.
+
+        ``selected_tools`` follows the same contract as
+        ``execute_tool_call()``: omitting it or passing ``None`` uses the
+        default behavior of exposing all tools, ``[]`` exposes no tools, and
+        a non-empty list restricts execution to the named tools.
         """
         system_prompt = "You are an executor that executes the plan given to you in the prompt through tool calls."
         self.agent.llm.system_prompt = system_prompt

--- a/mesa_llm/reasoning/rewoo.py
+++ b/mesa_llm/reasoning/rewoo.py
@@ -106,7 +106,12 @@ class ReWOOReasoning(Reasoning):
         selected_tools: list[str] | None = None,
     ) -> Plan:
         """
-        Plan the next (ReWOO) action based on the current observation and the agent's memory.
+        Plan the next (ReWOO) action based on the current observation and memory.
+
+        ``selected_tools`` is forwarded to ``ToolManager.get_all_tools_schema()``.
+        Omitting it or passing ``None`` uses the default behavior of exposing
+        all tools, ``[]`` exposes no tools, and a non-empty list restricts
+        planning/execution to the named tools.
         """
         # If we have remaining tool calls, skip observation and plan generation
         if self.remaining_tool_calls > 0:
@@ -167,6 +172,11 @@ class ReWOOReasoning(Reasoning):
     ) -> Plan:
         """
         Asynchronous version of plan() method for parallel planning.
+
+        ``selected_tools`` follows the same contract as ``plan()``: omitting
+        it or passing ``None`` uses the default behavior of exposing all
+        tools, ``[]`` exposes no tools, and a non-empty list restricts
+        planning/execution to the named tools.
         """
         # If we have remaining tool calls, skip observation and plan generation
         if self.remaining_tool_calls > 0:

--- a/mesa_llm/tools/tool_manager.py
+++ b/mesa_llm/tools/tool_manager.py
@@ -69,6 +69,13 @@ class ToolManager:
     def get_all_tools_schema(
         self, selected_tools: list[str] | None = None
     ) -> list[dict]:
+        """Return schemas for all tools or an explicit selection.
+
+        Omitting ``selected_tools`` or passing ``None`` uses the default
+        behavior of returning all registered tools.
+        ``selected_tools=[]`` returns no tools.
+        A non-empty list returns only the named tools in the given order.
+        """
         if selected_tools is not None:
             return [self.tools[tool].__tool_schema__ for tool in selected_tools]
 

--- a/mesa_llm/tools/tool_manager.py
+++ b/mesa_llm/tools/tool_manager.py
@@ -69,14 +69,10 @@ class ToolManager:
     def get_all_tools_schema(
         self, selected_tools: list[str] | None = None
     ) -> list[dict]:
-        if selected_tools:
-            selected_tools_schema = [
-                self.tools[tool].__tool_schema__ for tool in selected_tools
-            ]
-            return selected_tools_schema
+        if selected_tools is not None:
+            return [self.tools[tool].__tool_schema__ for tool in selected_tools]
 
-        else:
-            return [fn.__tool_schema__ for fn in self.tools.values()]
+        return [fn.__tool_schema__ for fn in self.tools.values()]
 
     def call(self, name: str, arguments: dict) -> str:
         """Call a registered tool with validated args"""

--- a/tests/test_tools/test_tool_manager.py
+++ b/tests/test_tools/test_tool_manager.py
@@ -227,7 +227,7 @@ class TestToolManager:
         assert "tool_b" not in tool_names
 
     def test_get_all_tools_schema_empty_list(self):
-        """Test that empty list returns all tools (current behavior)."""
+        """Test that empty list returns no tools (selected_tools=[] means 'no tools')."""
 
         @tool
         def test_tool(agent, x: int) -> int:
@@ -242,11 +242,10 @@ class TestToolManager:
 
         manager = ToolManager()
 
-        # Empty list should return all tools (current behavior)
-        all_schemas = manager.get_all_tools_schema()
+        # Empty list should return no tools — the user explicitly asked for none
         empty_list_schemas = manager.get_all_tools_schema([])
 
-        assert len(empty_list_schemas) == len(all_schemas)
+        assert len(empty_list_schemas) == 0
 
     def test_get_all_tools_schema_none(self):
         """Test that None returns all tools."""


### PR DESCRIPTION
`get_all_tools_schema()` checks `if selected_tools:` to decide whether to filter tools.
The problem is that `[]` is falsy in Python, so `selected_tools=[]` hits the `else` branch and returns every registered tool - the opposite of what the caller asked for.

I ran into this while building models in my [GSoC learning space](https://github.com/AdityaChauhanX07/GSoC-learning-space).
My `hello_llm_agent` model passes `selected_tools=[]` with a system prompt saying "never use tools," but agents were still calling `teleport_to_location` because the schemas were getting injected anyway.

The fix is changing `if selected_tools:` to `if selected_tools is not None:` so that:
- `None` → all tools (default, unchanged)
- `[]` → no tools (the actual opt-out)
- `["tool_a"]` → just those tools (unchanged)

Also updated `test_get_all_tools_schema_empty_list` which was asserting the buggy behavior as "current behavior."

All 275 tests pass, 0 failures.

**Note:** This is technically a breaking change for any code that passed `selected_tools=[]` expecting all tools. The previous behavior was a bug - the test documenting it was labeled "current behavior" not "intended behavior."