### PR TITLE
fix(llm_agent): initialize self.recorder so @record_model can attach it

### DIFF
--- a/mesa_llm/llm_agent.py
+++ b/mesa_llm/llm_agent.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import logging
 import warnings
+from typing import TYPE_CHECKING
 
 from mesa.agent import Agent
 from mesa.discrete_space import (
@@ -23,6 +26,9 @@ from mesa_llm.reasoning.reasoning import (
 from mesa_llm.tools.tool_manager import ToolManager
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from mesa_llm.recording.simulation_recorder import SimulationRecorder
 
 
 class LLMAgent(Agent):
@@ -85,6 +91,9 @@ class LLMAgent(Agent):
 
         # display coordination
         self._step_display_data = {}
+
+        # Placeholder so @record_model can attach the SimulationRecorder
+        self.recorder: SimulationRecorder | None = None
 
         if isinstance(internal_state, str):
             internal_state = [internal_state]

--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -974,6 +974,25 @@ def test_send_message_stores_serializable_ids(monkeypatch):
     assert data["message"] == "hello"
 
 
+# ---------------------------------------------------------------------------
+# recorder attribute initialised to None (#218)
+# ---------------------------------------------------------------------------
+
+
+def test_llm_agent_has_recorder_attribute():
+    """LLMAgent instances must expose a `recorder` attribute so that
+    @record_model can attach a SimulationRecorder via hasattr()."""
+    model = Model(rng=42)
+    agent = LLMAgent(
+        model=model,
+        reasoning=ReActReasoning,
+        system_prompt="test",
+    )
+
+    assert hasattr(agent, "recorder")
+    assert agent.recorder is None
+
+
 @pytest.mark.asyncio
 async def test_asend_message_stores_serializable_ids(monkeypatch):
     """asend_message stores sender/recipients as unique_ids, not Agent objects."""

--- a/tests/test_recording/test_record_model.py
+++ b/tests/test_recording/test_record_model.py
@@ -3,7 +3,10 @@
 from unittest.mock import Mock, patch
 
 from mesa.model import Model
+from mesa.space import MultiGrid
 
+from mesa_llm.llm_agent import LLMAgent
+from mesa_llm.reasoning.react import ReActReasoning
 from mesa_llm.recording.record_model import _attach_recorder_to_agents, record_model
 from mesa_llm.recording.simulation_recorder import SimulationRecorder
 
@@ -263,3 +266,25 @@ class TestRecordModelDecorator:
         assert model1.recorder != model2.recorder
         assert model1.recorder.output_dir == temp_dir / "model1"
         assert model2.recorder.output_dir == temp_dir / "model2"
+
+    def test_recorder_attached_to_llm_agents(self, temp_dir):
+        """LLMAgent instances get the recorder attached by @record_model (#218)."""
+
+        @record_model(output_dir=str(temp_dir))
+        class AgentModel(Model):
+            def __init__(self):
+                super().__init__(rng=42)
+                self.grid = MultiGrid(3, 3, torus=False)
+                agent = LLMAgent(
+                    model=self,
+                    reasoning=ReActReasoning,
+                    system_prompt="test",
+                )
+                self.grid.place_agent(agent, (1, 1))
+
+        model = AgentModel()
+        agent = next(iter(model.agents))
+
+        # The recorder must have been propagated to the LLMAgent
+        assert agent.recorder is model.recorder
+        assert isinstance(agent.recorder, SimulationRecorder)


### PR DESCRIPTION
## Summary

`LLMAgent.__init__` never initialized `self.recorder`, so the `hasattr(agent, "recorder")` check in `_attach_recorder_to_agents()` always returned `False`. This meant the `@record_model` decorator silently never attached the `SimulationRecorder` to any `LLMAgent` instance.

### Changes

- **`mesa_llm/llm_agent.py`**: Add `self.recorder: SimulationRecorder | None = None` in `__init__`, with a `TYPE_CHECKING` import to avoid circular imports.
- **`tests/test_llm_agent.py`**: Add unit test verifying `hasattr(agent, "recorder")` returns `True` and defaults to `None`.
- **`tests/test_recording/test_record_model.py`**: Add integration test verifying `@record_model` successfully propagates the recorder to `LLMAgent` instances created during model init.

## Test plan

- [x] `pytest tests/test_llm_agent.py::test_llm_agent_has_recorder_attribute -xvs` passes
- [x] `pytest tests/test_recording/test_record_model.py::TestRecordModelDecorator::test_recorder_attached_to_llm_agents -xvs` passes
- [x] Full test suite (284 tests) passes with no regressions
- [x] `ruff check` and all pre-commit hooks pass

Closes #218