### PR TITLE
feat: propagate api_base property for local LLM support

### DIFF
--- a/docs/apis/llm_agent.md
+++ b/docs/apis/llm_agent.md
@@ -15,10 +15,10 @@ class MyAgent(LLMAgent):
             reasoning=CoTReasoning,
             llm_model="openai/gpt-4o",
             system_prompt="You are a helpful agent in a simulation.",
-            api_base=None,  # Set to a custom URL for self-hosted LLMs (e.g., "http://192.168.1.100:11434")
             vision=2,  # See 2 cells in each direction
             internal_state=["curious", "cooperative"],
-            step_prompt="Decide what to do next based on your observations."
+            step_prompt="Decide what to do next based on your observations.",
+            api_base=None,  # Set to a custom URL for self-hosted LLMs (e.g., "http://192.168.1.100:11434")
       )
 
       # You can override default memory with EpisodicMemory (default is STLTMemory)

--- a/docs/apis/llm_agent.md
+++ b/docs/apis/llm_agent.md
@@ -9,13 +9,13 @@ from mesa_llm.llm_agent import LLMAgent
 from mesa_llm.reasoning.cot import CoTReasoning
 
 class MyAgent(LLMAgent):
-   def __init__(self, model, api_key, **kwargs):
+   def __init__(self, model, **kwargs):
       super().__init__(
             model=model,
-            api_key=api_key,
             reasoning=CoTReasoning,
             llm_model="openai/gpt-4o",
             system_prompt="You are a helpful agent in a simulation.",
+            api_base=None,  # Set to a custom URL for self-hosted LLMs (e.g., "http://192.168.1.100:11434")
             vision=2,  # See 2 cells in each direction
             internal_state=["curious", "cooperative"],
             step_prompt="Decide what to do next based on your observations."
@@ -24,7 +24,6 @@ class MyAgent(LLMAgent):
       # You can override default memory with EpisodicMemory (default is STLTMemory)
       self.memory = EpisodicMemory(
             agent=self,
-            api_key=api_key,
             llm_model="openai/gpt-4o-mini",
             max_memory=20
       )

--- a/docs/apis/memory.md
+++ b/docs/apis/memory.md
@@ -9,17 +9,17 @@ from mesa_llm.llm_agent import LLMAgent
 from mesa_llm.memory.st_lt_memory import STLTMemory
 
 class MyAgent(LLMAgent):
-   def __init__(self, model, api_key, reasoning, **kwargs):
-      super().__init__(model, api_key, reasoning, **kwargs)
+   def __init__(self, model, reasoning, **kwargs):
+      super().__init__(model, reasoning, **kwargs)
 
       # Override default memory with custom configuration
       self.memory = STLTMemory(
             agent=self,
             short_term_capacity=10,    # Store 10 recent experiences
             consolidation_capacity=3, # Consolidate when 13 total entries
-            api_key=api_key,
             llm_model="openai/gpt-4o-mini",
-            display=True            # Display the memory entries in the console when they are added to the memory
+            api_base=None,            # Set to a custom URL for self-hosted LLMs
+            display=True              # Display the memory entries in the console when they are added to the memory
       )
 ```
 

--- a/docs/apis/memory.md
+++ b/docs/apis/memory.md
@@ -18,8 +18,8 @@ class MyAgent(LLMAgent):
             short_term_capacity=10,    # Store 10 recent experiences
             consolidation_capacity=3, # Consolidate when 13 total entries
             llm_model="openai/gpt-4o-mini",
+            display=True,             # Display the memory entries in the console when they are added to the memory
             api_base=None,            # Set to a custom URL for self-hosted LLMs
-            display=True              # Display the memory entries in the console when they are added to the memory
       )
 ```
 

--- a/docs/apis/module_llm.md
+++ b/docs/apis/module_llm.md
@@ -36,15 +36,15 @@ from mesa_llm.module_llm import ModuleLLM
 # Connect to a remote Ollama instance
 llm = ModuleLLM(
    llm_model="ollama_chat/llama3.2",
+   system_prompt="You are a helpful agent.",
    api_base="http://192.168.1.100:11434",
-   system_prompt="You are a helpful agent."
 )
 
 # Connect to a local LM Studio server
 llm = ModuleLLM(
    llm_model="openai/my-local-model",
+   system_prompt="You are a helpful agent.",
    api_base="http://localhost:1234/v1",
-   system_prompt="You are a helpful agent."
 )
 ```
 

--- a/docs/apis/module_llm.md
+++ b/docs/apis/module_llm.md
@@ -26,13 +26,39 @@ llm = ModuleLLM(
 response = llm.generate("What should I do next in this situation?")
 ```
 
+## Custom API Endpoints
+
+If you are using a self-hosted or remote LLM server (e.g., Ollama on another machine, vLLM, LM Studio), you can specify a custom API endpoint using the `api_base` parameter:
+
+```python
+from mesa_llm.module_llm import ModuleLLM
+
+# Connect to a remote Ollama instance
+llm = ModuleLLM(
+   llm_model="ollama_chat/llama3.2",
+   api_base="http://192.168.1.100:11434",
+   system_prompt="You are a helpful agent."
+)
+
+# Connect to a local LM Studio server
+llm = ModuleLLM(
+   llm_model="openai/my-local-model",
+   api_base="http://localhost:1234/v1",
+   system_prompt="You are a helpful agent."
+)
+```
+
+> **Note:** For standard Ollama running locally on the default port, `api_base` is optional — it defaults to `http://localhost:11434`. For cloud providers (OpenAI, Anthropic, Google, Groq, etc.), `api_base` is not needed as the URLs are automatically resolved by the LiteLLM library.
+
+The `api_base` parameter is supported across all layers of Mesa-LLM: `ModuleLLM`, `LLMAgent`, and all `Memory` subclasses (`STLTMemory`, `EpisodicMemory`, `LongTermMemory`).
+
 ## Tool Integration
 
 ```python
 from mesa_llm.tools.tool_manager import ToolManager
 
 tool_manager = ToolManager()
-llm = ModuleLLM(api_key="key", llm_model="openai/gpt-4o")
+llm = ModuleLLM(llm_model="openai/gpt-4o")
 
 # Generate with tool calling
 response = llm.generate(
@@ -87,10 +113,9 @@ decision = AgentDecision.parse_raw(response.choices[0].message.content)
 
 ```python
 class MyAgent(LLMAgent):
-   def __init__(self, model, api_key, **kwargs):
+   def __init__(self, model, **kwargs):
       super().__init__(
             model=model,
-            api_key=api_key,
             llm_model="anthropic/claude-3-sonnet",  # Automatically creates ModuleLLM
             system_prompt="Custom agent behavior instructions",
             **kwargs

--- a/docs/apis/reasoning.md
+++ b/docs/apis/reasoning.md
@@ -9,10 +9,9 @@ from mesa_llm.llm_agent import LLMAgent
 from mesa_llm.reasoning.cot import CoTReasoning
 
 class MyAgent(LLMAgent):
-   def __init__(self, model, api_key, **kwargs):
+   def __init__(self, model, **kwargs):
       super().__init__(
             model=model,
-            api_key=api_key,
             reasoning=CoTReasoning,  # Specify reasoning strategy
             **kwargs
       )

--- a/examples/epstein_civil_violence/agents.py
+++ b/examples/epstein_civil_violence/agents.py
@@ -16,7 +16,6 @@ class CitizenState(Enum):
     ACTIVE = 2
     ARRESTED = 3
 
-
 class Citizen(LLMAgent, mesa.discrete_space.CellAgent):
     """
     A member of the general population, may or may not be in active rebellion.
@@ -52,6 +51,7 @@ class Citizen(LLMAgent, mesa.discrete_space.CellAgent):
         arrest_prob_constant=0.5,
         regime_legitimacy=0.5,
         threshold=0.5,
+        api_base=None,
     ):
         # Call the superclass constructor with updated internal state
         super().__init__(
@@ -62,6 +62,7 @@ class Citizen(LLMAgent, mesa.discrete_space.CellAgent):
             vision=vision,
             internal_state=internal_state,
             step_prompt=step_prompt,
+            api_base=api_base,
         )
 
         self.hardship = self.random.random()
@@ -77,7 +78,8 @@ class Citizen(LLMAgent, mesa.discrete_space.CellAgent):
         self.memory = STLTMemory(
             agent=self,
             display=True,
-            llm_model="openai/gpt-4o-mini",
+            llm_model=llm_model,
+            api_base=api_base,
         )
 
         self.threshold = threshold
@@ -176,6 +178,7 @@ class Cop(LLMAgent, mesa.discrete_space.CellAgent):
         internal_state,
         step_prompt,
         max_jail_term=2,
+        api_base=None,
     ):
         """
         Create a new Cop.
@@ -193,6 +196,7 @@ class Cop(LLMAgent, mesa.discrete_space.CellAgent):
             vision=vision,
             internal_state=internal_state,
             step_prompt=step_prompt,
+            api_base=api_base,
         )
         self.max_jail_term = max_jail_term
         self.tool_manager = cop_tool_manager
@@ -201,7 +205,8 @@ class Cop(LLMAgent, mesa.discrete_space.CellAgent):
         self.memory = STLTMemory(
             agent=self,
             display=True,
-            llm_model="openai/gpt-4o-mini",
+            llm_model=llm_model,
+            api_base=api_base,
         )
 
     def step(self):

--- a/examples/epstein_civil_violence/agents.py
+++ b/examples/epstein_civil_violence/agents.py
@@ -16,6 +16,7 @@ class CitizenState(Enum):
     ACTIVE = 2
     ARRESTED = 3
 
+
 class Citizen(LLMAgent, mesa.discrete_space.CellAgent):
     """
     A member of the general population, may or may not be in active rebellion.

--- a/examples/epstein_civil_violence/app.py
+++ b/examples/epstein_civil_violence/app.py
@@ -49,6 +49,7 @@ model_params = {
     "height": 10,
     "reasoning": ReActReasoning,
     "llm_model": "openai/gpt-4o-mini",
+    "api_base": None,
     "vision": 5,
     "parallel_stepping": True,
 }
@@ -62,6 +63,7 @@ model = EpsteinModel(
     reasoning=model_params["reasoning"],
     llm_model=model_params["llm_model"],
     vision=model_params["vision"],
+    api_base=model_params["api_base"],
     seed=model_params["seed"]["value"],
     parallel_stepping=model_params["parallel_stepping"],
 )

--- a/examples/epstein_civil_violence/model.py
+++ b/examples/epstein_civil_violence/model.py
@@ -19,6 +19,7 @@ class EpsteinModel(Model):
         reasoning: type[Reasoning],
         llm_model: str,
         vision: int,
+        api_base: str | None = None,
         parallel_stepping=True,
         seed=None,
     ):
@@ -65,6 +66,7 @@ class EpsteinModel(Model):
             vision=vision,
             internal_state=None,
             step_prompt="Inspect your local vision and arrest a random active agent. Move if applicable.",
+            api_base=api_base,
         )
 
         x = self.rng.integers(0, self.grid.width, size=(initial_cops,))
@@ -82,6 +84,7 @@ class EpsteinModel(Model):
             vision=vision,
             internal_state=None,
             step_prompt="Move around and change your state if the conditions indicate it.",
+            api_base=api_base,
         )
 
         x = self.rng.integers(0, self.grid.width, size=(initial_citizens,))

--- a/examples/negotiation/agents.py
+++ b/examples/negotiation/agents.py
@@ -77,12 +77,14 @@ class SellerAgent(LLMAgent):
         system_prompt,
         vision,
         internal_state,
+        api_base=None,
     ):
         super().__init__(
             model=model,
             reasoning=reasoning,
             llm_model=llm_model,
             system_prompt=system_prompt,
+            api_base=api_base,
             vision=vision,
             internal_state=internal_state,
         )
@@ -137,12 +139,14 @@ class BuyerAgent(LLMAgent):
         vision,
         internal_state,
         budget,
+        api_base=None,
     ):
         super().__init__(
             model=model,
             reasoning=reasoning,
             llm_model=llm_model,
             system_prompt=system_prompt,
+            api_base=api_base,
             vision=vision,
             internal_state=internal_state,
         )

--- a/examples/negotiation/app.py
+++ b/examples/negotiation/app.py
@@ -42,6 +42,7 @@ model_params = {
     "reasoning": ReActReasoning,
     "llm_model": "openai/gpt-4o",
     "vision": 5,
+    "api_base": None,
 }
 
 
@@ -52,6 +53,7 @@ model = NegotiationModel(
     reasoning=model_params["reasoning"],
     llm_model=model_params["llm_model"],
     vision=model_params["vision"],
+    api_base=model_params["api_base"],
     seed=model_params["seed"]["value"],
 )
 

--- a/examples/negotiation/model.py
+++ b/examples/negotiation/model.py
@@ -29,6 +29,7 @@ class NegotiationModel(Model):
         reasoning: type[Reasoning],
         llm_model: str,
         vision: int,
+        api_base: str | None = None,
         seed=None,
         parallel_stepping=True,
     ):
@@ -51,6 +52,7 @@ class NegotiationModel(Model):
             vision=vision,
             internal_state=buyer_internal_state,
             budget=50,  # Each buyer has a budget of $50
+            api_base=api_base,
         )
 
         x = self.rng.integers(0, self.grid.width, size=(initial_buyers,))
@@ -67,6 +69,7 @@ class NegotiationModel(Model):
             vision=vision,
             internal_state=buyer_internal_state,
             budget=100,
+            api_base=api_base,
         )
 
         x = self.rng.integers(0, self.grid.width, size=(initial_buyers,))
@@ -82,6 +85,7 @@ class NegotiationModel(Model):
             system_prompt="You are a Seller in a negotiation game trying to sell shoes($40) and track suit($50) of brand A. You are trying to pitch your product to the Buyer type Agents. You are extremely good at persuading, and have good sales skills. You are also hardworking and dedicated to your work. To do any action, you must use the tools provided to you.",
             vision=vision,
             internal_state=["hardworking", "dedicated", "persuasive"],
+            api_base=api_base,
         )
         self.grid.place_agent(
             seller_a,
@@ -97,6 +101,7 @@ class NegotiationModel(Model):
             system_prompt="You are a Seller in a negotiation game trying to sell shoes($35) and track suit($47) of brand B. You are trying to pitch your product to the Buyer type Agents. You are not interested in your work and are doing it for the sake of doing. To do any action, you must use the tools provided to you.",
             vision=vision,
             internal_state=["lazy", "unmotivated"],
+            api_base=api_base,
         )
         self.grid.place_agent(
             seller_b,

--- a/examples/sugarscrap_g1mt/agents.py
+++ b/examples/sugarscrap_g1mt/agents.py
@@ -22,6 +22,7 @@ class Trader(LLMAgent, mesa.discrete_space.CellAgent):
         spice=0,
         metabolism_sugar=1,
         metabolism_spice=1,
+        api_base=None,
     ):
         super().__init__(
             model=model,
@@ -31,6 +32,7 @@ class Trader(LLMAgent, mesa.discrete_space.CellAgent):
             vision=vision,
             internal_state=internal_state,
             step_prompt=step_prompt,
+            api_base=api_base,
         )
         self.sugar = sugar
         self.spice = spice
@@ -43,7 +45,8 @@ class Trader(LLMAgent, mesa.discrete_space.CellAgent):
         self.memory = STLTMemory(
             agent=self,
             display=True,
-            llm_model="openai/gpt-4o-mini",
+            llm_model=llm_model,
+            api_base=api_base,
         )
 
         self.tool_manager = trader_tool_manager

--- a/examples/sugarscrap_g1mt/app.py
+++ b/examples/sugarscrap_g1mt/app.py
@@ -41,6 +41,7 @@ model_params = {
     "height": 10,
     "reasoning": ReActReasoning,
     "llm_model": "gemini/gemini-2.5-flash",
+    "api_base": None,
     "vision": 5,
     "parallel_stepping": False,
 }
@@ -53,6 +54,7 @@ model = SugarScapeModel(
     reasoning=model_params["reasoning"],
     llm_model=model_params["llm_model"],
     vision=model_params["vision"],
+    api_base=model_params["api_base"],
     seed=model_params["seed"]["value"],
     parallel_stepping=model_params["parallel_stepping"],
 )

--- a/examples/sugarscrap_g1mt/model.py
+++ b/examples/sugarscrap_g1mt/model.py
@@ -38,6 +38,7 @@ class SugarScapeModel(Model):
         reasoning: type[Reasoning],
         llm_model: str,
         vision: int,
+        api_base: str | None = None,
         parallel_stepping=True,
         seed=None,
     ):
@@ -115,6 +116,7 @@ class SugarScapeModel(Model):
             vision=vision,
             internal_state=None,
             step_prompt="Observe your inventory and MRS. Move to the best resource or propose a trade.",
+            api_base=api_base,
         )
 
         x_pos = self.rng.integers(0, self.grid.width, size=(initial_traders,))

--- a/mesa_llm/llm_agent.py
+++ b/mesa_llm/llm_agent.py
@@ -42,6 +42,7 @@ class LLMAgent(Agent):
         reasoning: type[Reasoning],
         llm_model: str = "gemini/gemini-2.0-flash",
         system_prompt: str | None = None,
+        api_base: str | None = None,
         vision: float | None = None,
         internal_state: list[str] | str | None = None,
         step_prompt: str | None = None,
@@ -50,13 +51,14 @@ class LLMAgent(Agent):
 
         self.model = model
         self.step_prompt = step_prompt
-        self.llm = ModuleLLM(llm_model=llm_model, system_prompt=system_prompt)
+        self.llm = ModuleLLM(llm_model=llm_model, system_prompt=system_prompt, api_base=api_base)
 
         self.memory = STLTMemory(
             agent=self,
             short_term_capacity=5,
             consolidation_capacity=2,
             llm_model=llm_model,
+            api_base=api_base,
         )
 
         self.tool_manager = ToolManager()

--- a/mesa_llm/llm_agent.py
+++ b/mesa_llm/llm_agent.py
@@ -25,15 +25,24 @@ class LLMAgent(Agent):
     LLMAgent manages an LLM backend and optionally connects to a memory module.
 
     Parameters:
-        model (Model): The mesa model the agent in linked to.
-        llm_model (str): The model to use for the LLM in the format 'provider/model'. Defaults to 'gemini/gemini-2.0-flash'.
-        system_prompt (str | None): Optional system prompt to be used in LLM completions.
-        reasoning (str): Optional reasoning method to be used in LLM completions.
+        model (Model): The Mesa model the agent belongs to.
+        reasoning (type[Reasoning]): The reasoning strategy used by the agent.
+        llm_model (str): The model to use for the LLM in the format
+            ``provider/model``. Defaults to ``gemini/gemini-2.0-flash``.
+        system_prompt (str | None): Optional system prompt for the LLM.
+        vision (float | None): Observation radius for nearby agents. Use ``-1``
+            to observe all agents in the simulation.
+        internal_state (list[str] | str | None): Optional internal state facts
+            exposed to the reasoning module.
+        step_prompt (str | None): Optional task-specific prompt used to guide
+            the agent each step.
+        api_base (str | None): Optional custom LiteLLM-compatible base URL for
+            self-hosted or remote inference endpoints.
 
     Attributes:
         llm (ModuleLLM): The internal LLM interface used by the agent.
         memory (Memory | None): The memory module attached to this agent, if any.
-
+        tool_manager (ToolManager): The tool registry available to the agent.
     """
 
     def __init__(
@@ -42,10 +51,10 @@ class LLMAgent(Agent):
         reasoning: type[Reasoning],
         llm_model: str = "gemini/gemini-2.0-flash",
         system_prompt: str | None = None,
-        api_base: str | None = None,
         vision: float | None = None,
         internal_state: list[str] | str | None = None,
         step_prompt: str | None = None,
+        api_base: str | None = None,
     ):
         super().__init__(model=model)
 

--- a/mesa_llm/llm_agent.py
+++ b/mesa_llm/llm_agent.py
@@ -51,7 +51,9 @@ class LLMAgent(Agent):
 
         self.model = model
         self.step_prompt = step_prompt
-        self.llm = ModuleLLM(llm_model=llm_model, system_prompt=system_prompt, api_base=api_base)
+        self.llm = ModuleLLM(
+            llm_model=llm_model, system_prompt=system_prompt, api_base=api_base
+        )
 
         self.memory = STLTMemory(
             agent=self,

--- a/mesa_llm/memory/episodic_memory.py
+++ b/mesa_llm/memory/episodic_memory.py
@@ -64,6 +64,7 @@ class EpisodicMemory(Memory):
         self,
         agent: "LLMAgent",
         llm_model: str | None = None,
+        api_base: str | None = None,
         display: bool = True,
         max_capacity: int = 200,
         considered_entries: int = 30,
@@ -77,7 +78,7 @@ class EpisodicMemory(Memory):
                 "llm_model must be provided for the usage of episodic memory"
             )
 
-        super().__init__(agent, llm_model=llm_model, display=display)
+        super().__init__(agent, llm_model=llm_model, api_base=api_base, display=display)
 
         self.max_capacity = max_capacity
         self.memory_entries = deque(maxlen=self.max_capacity)

--- a/mesa_llm/memory/episodic_memory.py
+++ b/mesa_llm/memory/episodic_memory.py
@@ -64,14 +64,23 @@ class EpisodicMemory(Memory):
         self,
         agent: "LLMAgent",
         llm_model: str | None = None,
-        api_base: str | None = None,
         display: bool = True,
         max_capacity: int = 200,
         considered_entries: int = 30,
         recency_decay: float = 0.995,
+        api_base: str | None = None,
     ):
         """
-        Initialize the EpisodicMemory
+        Initialize the EpisodicMemory.
+
+        Args:
+            agent : the agent that owns this memory
+            llm_model : the model used to grade event importance
+            display : whether to display memory entries in the console
+            max_capacity : maximum number of finalized episodic entries to keep
+            considered_entries : number of entries to consider during retrieval
+            recency_decay : exponential decay factor for recency scoring
+            api_base : the API base URL to use for the LLM provider
         """
         if not llm_model:
             raise ValueError(

--- a/mesa_llm/memory/lt_memory.py
+++ b/mesa_llm/memory/lt_memory.py
@@ -22,6 +22,7 @@ class LongTermMemory(Memory):
         agent: "LLMAgent",
         display: bool = True,
         llm_model: str = "openai/gpt-4o-mini",
+        api_base: str | None = None,
     ):
         if not llm_model:
             raise ValueError(
@@ -31,6 +32,7 @@ class LongTermMemory(Memory):
         super().__init__(
             agent=agent,
             llm_model=llm_model,
+            api_base=api_base,
             display=display,
         )
 

--- a/mesa_llm/memory/memory.py
+++ b/mesa_llm/memory/memory.py
@@ -110,16 +110,17 @@ class Memory(ABC):
         self,
         agent: "LLMAgent",
         llm_model: str | None = None,
-        api_base: str | None = None,
         display: bool = True,
+        api_base: str | None = None,
     ):
         """
         Initialize the memory
 
         Args:
-            llm_model : the model to use for the summarization
-            api_base : the API base URL to use for the LLM provider
             agent : the agent that the memory belongs to
+            llm_model : the model to use for summarization
+            display : whether to display memory entries in the console
+            api_base : the API base URL to use for the LLM provider
         """
         self.agent = agent
         if llm_model:

--- a/mesa_llm/memory/memory.py
+++ b/mesa_llm/memory/memory.py
@@ -110,6 +110,7 @@ class Memory(ABC):
         self,
         agent: "LLMAgent",
         llm_model: str | None = None,
+        api_base: str | None = None,
         display: bool = True,
     ):
         """
@@ -117,11 +118,12 @@ class Memory(ABC):
 
         Args:
             llm_model : the model to use for the summarization
+            api_base : the API base URL to use for the LLM provider
             agent : the agent that the memory belongs to
         """
         self.agent = agent
         if llm_model:
-            self.llm = ModuleLLM(llm_model=llm_model)
+            self.llm = ModuleLLM(llm_model=llm_model, api_base=api_base)
 
         self.display = display
 

--- a/mesa_llm/memory/st_lt_memory.py
+++ b/mesa_llm/memory/st_lt_memory.py
@@ -33,6 +33,7 @@ class STLTMemory(Memory):
         consolidation_capacity: int = 2,
         display: bool = True,
         llm_model: str | None = None,
+        api_base: str | None = None,
     ):
         """
         Initialize the memory
@@ -40,6 +41,7 @@ class STLTMemory(Memory):
         Args:
             short_term_capacity : the number of interactions to store in the short term memory
             llm_model : the model to use for the summarization
+            api_base : the API base URL to use for the LLM provider
             agent : the agent that the memory belongs to
         """
         if not llm_model:
@@ -50,6 +52,7 @@ class STLTMemory(Memory):
         super().__init__(
             agent=agent,
             llm_model=llm_model,
+            api_base=api_base,
             display=display,
         )
 


### PR DESCRIPTION
## Description

This PR propagates `api_base` across the Mesa-LLM stack so users can configure local or self-hosted LLM endpoints (e.g., remote Ollama, vLLM, LM Studio) from application-level APIs.

Previously, `api_base` was supported in `ModuleLLM` but not consistently exposed through higher-level abstractions such as [LLMAgent](cci:2://file:///home/ahmednabil/Desktop/Org_mesa_cp/mesa-llm/mesa_llm/llm_agent.py:22:0-367:32) and memory modules, which made custom endpoint configuration incomplete in end-to-end usage.

This PR also removes hardcoded model usage in example memory initialization paths so summarization uses the configured `llm_model`.

## Changes

- Propagate `api_base` through [LLMAgent](cci:2://file:///home/ahmednabil/Desktop/Org_mesa_cp/mesa-llm/mesa_llm/llm_agent.py:22:0-367:32), [Memory](cci:2://file:///home/ahmednabil/Desktop/Org_mesa_cp/mesa-llm/mesa_llm/memory/memory.py:93:0-180:48), [STLTMemory](cci:2://file:///home/ahmednabil/Desktop/Org_mesa_cp/mesa-llm/mesa_llm/memory/st_lt_memory.py:9:0-213:9), [EpisodicMemory](cci:2://file:///home/ahmednabil/Desktop/Org_mesa_cp/mesa-llm/mesa_llm/memory/episodic_memory.py:46:0-274:14), and [LongTermMemory](cci:2://file:///home/ahmednabil/Desktop/Org_mesa_cp/mesa-llm/mesa_llm/memory/lt_memory.py:8:0-155:64).
- Forward `api_base` from top-level abstractions into `ModuleLLM`.
- Update examples to pass `api_base` from [app.py](cci:7://file:///home/ahmednabil/Desktop/Org_mesa_cp/mesa-llm/examples/negotiation/app.py:0:0-0:0) → [model.py](cci:7://file:///home/ahmednabil/Desktop/Org_mesa_cp/mesa-llm/examples/negotiation/model.py:0:0-0:0) → [agents.py](cci:7://file:///home/ahmednabil/Desktop/Org_mesa_cp/mesa-llm/examples/negotiation/agents.py:0:0-0:0).
- Update docs for `ModuleLLM`, [LLMAgent](cci:2://file:///home/ahmednabil/Desktop/Org_mesa_cp/mesa-llm/mesa_llm/llm_agent.py:22:0-367:32), and [Memory](cci:2://file:///home/ahmednabil/Desktop/Org_mesa_cp/mesa-llm/mesa_llm/memory/memory.py:93:0-180:48) with `api_base` usage examples.
- Remove deprecated `api_key` references from documentation.

## Checklist
- [x] I have read the `CONTRIBUTING` document.
- [x] My code follows project style guidelines.
- [ ] I added/updated tests for new behavior.
- [x] I ran existing tests and all passed.
- [x] I updated documentation.
