### PR TITLE
re-enable RUF012, B017, PGH004 linting rules and fix violations

### DIFF
--- a/mesa_llm/tools/tool_manager.py
+++ b/mesa_llm/tools/tool_manager.py
@@ -4,7 +4,7 @@ import inspect
 import json
 import logging
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from terminal_style import style
 
@@ -40,7 +40,7 @@ class ToolManager:
         6. **Result Handling**: Tool outputs are captured and added to agent memory for future reasoning
     """
 
-    instances: list["ToolManager"] = []
+    instances: ClassVar[list["ToolManager"]] = []
 
     def __init__(self, extra_tools: dict[str, Callable] | None = None):
         # start from everything that was decorated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,12 +100,9 @@ lint.select = [
 lint.extend-ignore = [
     "E501",
     "S101",   # Use of `assert` detected
-    "B017",   # `assertRaises(Exception)` should be considered evil TODO
-    "PGH004", # Use specific rule codes when using `noqa` TODO
     "B905",   # `zip()` without an explicit `strict=` parameter
     "N802",   # Function name should be lowercase
     "N999",   # Invalid module name. We should revisit this in the future, TODO
-    "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar` TODO
     "S310",   # Audit URL open for permitted schemes. Allowing use of `file:` or custom schemes is often unexpected.
     "S603",   # `subprocess` call: check for execution of untrusted input
     "ISC001", # ruff format asks to disable this feature


### PR DESCRIPTION
## What this does
Re-enables three TODO linting rules that were explicitly disabled in `pyproject.toml`:
- `RUF012` — mutable class variable annotations
- `B017` — `assertRaises(Exception)` should be considered evil
- `PGH004` — Use specific rule codes when using `noqa`

## Changes
- `pyproject.toml` — removed the three rules from the ignore list.
- `mesa_llm/tools/tool_manager.py` — fixed `RUF012` violation by properly annotating `instances` with `ClassVar`.

## Why this matters
These rules were marked as TODO in the configuration, indicating that the maintainers intended to enable them once violations were addressed. Enabling these rules helps prevent technical debt and ensures better code quality and type safety across the project.

## Tests
- [x] `ruff check .` -> 0 errors
- [x] `pytest tests/ -v` -> all passing locally