### PR TITLE
docs: fix incorrect api_key instruction in negotiation readme

### DIFF
--- a/examples/epstein_civil_violence/Readme.md
+++ b/examples/epstein_civil_violence/Readme.md
@@ -80,14 +80,12 @@ This design enables **flexible, context-aware decision-making** that incorporate
 
 ## How to Run
 
-If you have cloned the repo into your local machine, ensure you run the following command from the root of the library: ``pip install -e . ``. Then, you will need an api key of an LLM-provider of your choice. (This model in particular makes a large amount of calls per minute and we therefore recommend getting a paid version of an api-key that can offer high rate-limits). Once you have obtained the api-key follow the below steps to set it up for this model.
-1) Ensure the dotenv package is installed. If not, run ``pip install python-dotenv``.
-2) In the root folder of the project, create a file named .env.
-3) If you are using openAI's api key, add the following command in the .env file: ``OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxx``. If you have the paid version of Gemini, use this line instead: ``GEMINI_API_KEY=your-gemini-api-key-here``(the free ones tend to not work with this model).
-4) Change the  ``api_key`` specification in app.py according to the provider you have chosen.
-5) Similarly change the ``llm_model`` attribute as well in app.py to the name of a model you have access to. Ensure it is in the form of {provider}/{model_name}. For e.g. ``openai/gpt-4o-mini``.
+If you have cloned the repo into your local machine, run ``pip install -e .`` from the project root. Then obtain an API key for an LLM provider of your choice and follow the steps below to configure this model. This model makes a large number of calls per minute, so a paid API key with higher rate limits is recommended.
+1) Create a `.env` file in the project root.
+2) In `.env`, set the API key variable that matches the provider prefix in `llm_model`. For example: ``OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxx`` for `openai/...`, or ``GEMINI_API_KEY=your-gemini-api-key-here`` for `gemini/...`. The app uses `load_dotenv()` to load this automatically. If you use `ollama/...`, no API key is required, but you may need to configure `api_base` instead.
+3) Update the ``llm_model`` attribute in `app.py` to a model you have access to. Use the format ``{provider}/{model_name}``, for example ``openai/gpt-4o-mini``.
 
-Once you have set up the api-key in your system, run the following command from this directory:
+Once you have configured `.env` and `llm_model`, run the following command from this directory:
 
 ```
     $ solara run app.py

--- a/examples/negotiation/readme.md
+++ b/examples/negotiation/readme.md
@@ -34,16 +34,12 @@ The model tracks the number of sales for each seller using a data collector, all
 
 ## How to Run
 
-If you have cloned the repo into your local machine, ensure you run the following command from the root of the library: ``pip install -e . ``. Then, you will need an api key of an LLM-provider of your choice. Once you have obtained the api-key follow the below steps to set it up for this model.
-1) Ensure the dotenv package is installed. If not, run ``pip install python-dotenv``.
-2) In the root folder of the project, create a file named .env.
-3) If you are using openAI's api key, add the following command in the .env file: ``OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxx``. If you have a Gemini based api-key, use this line instead: ``GEMINI_API_KEY=your-gemini-api-key-here``.
-4) Create a `.env` file in the project root and add your API key:
-`OPENAI_API_KEY=your_api_key_here`
-The app uses `load_dotenv()` to load it automatically.
-5) Similarly change the ``llm_model`` attribute as well in app.py to the name of a model you have access to. Ensure it is in the form of {provider}/{model_name}. For e.g. ``openai/gpt-4o-mini``.
+If you have cloned the repo into your local machine, run ``pip install -e .`` from the project root. Then obtain an API key for an LLM provider of your choice and follow the steps below to configure this model.
+1) Create a `.env` file in the project root.
+2) In `.env`, set the API key variable that matches the provider prefix in `llm_model`. For example: ``OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxx`` for `openai/...`, ``GEMINI_API_KEY=your-gemini-api-key-here`` for `gemini/...`, or ``ANTHROPIC_API_KEY=your-anthropic-api-key-here`` for `anthropic/...`. The app uses `load_dotenv()` to load this automatically. If you use `ollama/...`, no API key is required, but you may need to configure `api_base` instead.
+3) Update the ``llm_model`` attribute in `app.py` to a model you have access to. Use the format ``{provider}/{model_name}``, for example ``openai/gpt-4o-mini``.
 
-Once you have set up the api-key in your system, run the following command from this directory:
+Once you have configured `.env` and `llm_model`, run the following command from this directory:
 
 ```
     $ solara run app.py

--- a/examples/negotiation/readme.md
+++ b/examples/negotiation/readme.md
@@ -38,7 +38,9 @@ If you have cloned the repo into your local machine, ensure you run the followin
 1) Ensure the dotenv package is installed. If not, run ``pip install python-dotenv``.
 2) In the root folder of the project, create a file named .env.
 3) If you are using openAI's api key, add the following command in the .env file: ``OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxx``. If you have a Gemini based api-key, use this line instead: ``GEMINI_API_KEY=your-gemini-api-key-here``.
-4) Change the  ``api_key`` specification in app.py according to the provider you have chosen.
+4) Create a `.env` file in the project root and add your API key:
+`OPENAI_API_KEY=your_api_key_here`
+The app uses `load_dotenv()` to load it automatically.
 5) Similarly change the ``llm_model`` attribute as well in app.py to the name of a model you have access to. Ensure it is in the form of {provider}/{model_name}. For e.g. ``openai/gpt-4o-mini``.
 
 Once you have set up the api-key in your system, run the following command from this directory:

--- a/examples/sugarscrap_g1mt/Readme.md
+++ b/examples/sugarscrap_g1mt/Readme.md
@@ -95,14 +95,12 @@ Both Traders and the simulation logic are driven by LLM-powered agents, meaning:
 
 ## How to Run
 
-If you have cloned the repo into your local machine, ensure you run the following command from the root of the library: ``pip install -e . ``. Then, you will need an api key of an LLM-provider of your choice. (This model in particular makes a large amount of calls per minute and we therefore recommend getting a paid version of an api-key that can offer high rate-limits). Once you have obtained the api-key follow the below steps to set it up for this model.
-1) Ensure the dotenv package is installed. If not, run ``pip install python-dotenv``.
-2) In the root folder of the project, create a file named .env.
-3) If you are using openAI's api key, add the following command in the .env file: ``OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxx``. If you have the paid version of Gemini, use this line instead: ``GEMINI_API_KEY=your-gemini-api-key-here``(the free ones tend to not work with this model).
-4) Change the  ``api_key`` specification in app.py according to the provider you have chosen.
-5) Similarly change the ``llm_model`` attribute as well in app.py to the name of a model you have access to. Ensure it is in the form of {provider}/{model_name}. For e.g. ``openai/gpt-4o-mini``.
+If you have cloned the repo into your local machine, run ``pip install -e .`` from the project root. Then obtain an API key for an LLM provider of your choice and follow the steps below to configure this model. This model makes a large number of calls per minute, so a paid API key with higher rate limits is recommended.
+1) Create a `.env` file in the project root.
+2) In `.env`, set the API key variable that matches the provider prefix in `llm_model`. For example: ``OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxx`` for `openai/...`, or ``GEMINI_API_KEY=your-gemini-api-key-here`` for `gemini/...`. The app uses `load_dotenv()` to load this automatically. If you use `ollama/...`, no API key is required, but you may need to configure `api_base` instead.
+3) Update the ``llm_model`` attribute in `app.py` to a model you have access to. Use the format ``{provider}/{model_name}``, for example ``openai/gpt-4o-mini``.
 
-Once you have set up the api-key in your system, run the following command from this directory:
+Once you have configured `.env` and `llm_model`, run the following command from this directory:
 
 ```
     $ solara run app.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 dependencies = [
     "mesa[rec]>=3.0",
     "litellm",
+    "python-dotenv",
     "terminal-style",
     "rich",
     "tenacity",


### PR DESCRIPTION
Fixes #248

The readme incorrectly instructed users to change api_key in app.py.
app.py actually uses load_dotenv() to load credentials from a .env file.
Updated the instruction to correctly reference the .env file approach.