### PR TITLE
improve RateLimitError message with actionable guidance

### DIFF
--- a/mesa_llm/module_llm.py
+++ b/mesa_llm/module_llm.py
@@ -104,6 +104,38 @@ class ModuleLLM:
 
         return messages
 
+    def _build_rate_limit_error(self, error: RateLimitError) -> RateLimitError:
+        provider = self.llm_model.split("/", 1)[0].lower()
+        docs_url = {
+            "anthropic": "https://platform.claude.com/docs/en/api/rate-limits",
+            "gemini": "https://ai.google.dev/gemini-api/docs/rate-limits",
+            "novita": "https://novita.ai/docs/guides/llm-rate-limits",
+            "openai": "https://developers.openai.com/api/docs/guides/rate-limits",
+            "openrouter": "https://openrouter.ai/docs/api/reference/limits",
+            "xai": "https://docs.x.ai/developers/rate-limits",
+        }.get(provider)
+
+        detail = error.message.removeprefix("litellm.RateLimitError: ").strip()
+        message_parts = [f"Rate limit exceeded for model '{self.llm_model}'."]
+        if detail:
+            message_parts.append(detail)
+        message_parts.append(
+            "Please wait a few minutes and try again, or switch to a different model."
+        )
+        if docs_url:
+            message_parts.append(f"To check your quota visit: {docs_url}")
+
+        message = " ".join(message_parts)
+        return RateLimitError(
+            message=message,
+            llm_provider=error.llm_provider,
+            model=error.model,
+            response=error.response,
+            litellm_debug_info=error.litellm_debug_info,
+            max_retries=error.max_retries,
+            num_retries=error.num_retries,
+        )
+
     @retry(
         wait=wait_exponential(multiplier=1, min=1, max=60),
         retry=retry_if_exception_type(RETRYABLE_EXCEPTIONS),
@@ -143,19 +175,8 @@ class ModuleLLM:
 
         try:
             response = completion(**completion_kwargs)
-        except RateLimitError as e:
-            raise RateLimitError(
-                message=(
-                    f"Rate limit exceeded for model '{self.llm_model}'. "
-                    "You have exceeded your API quota. "
-                    "Please wait a few minutes and try again, "
-                    "or switch to a different model. "
-                    "To check your quota visit: "
-                    "https://ai.google.dev/gemini-api/docs/rate-limits"
-                ),
-                llm_provider=self.llm_model.split("/")[0],
-                model=self.llm_model,
-            ) from e
+        except RateLimitError as error:
+            raise self._build_rate_limit_error(error) from error
 
         return response
 
@@ -186,5 +207,8 @@ class ModuleLLM:
                 if self.api_base:
                     completion_kwargs["api_base"] = self.api_base
 
-                response = await acompletion(**completion_kwargs)
+                try:
+                    response = await acompletion(**completion_kwargs)
+                except RateLimitError as error:
+                    raise self._build_rate_limit_error(error) from error
         return response

--- a/mesa_llm/module_llm.py
+++ b/mesa_llm/module_llm.py
@@ -141,7 +141,21 @@ class ModuleLLM:
         if self.api_base:
             completion_kwargs["api_base"] = self.api_base
 
-        response = completion(**completion_kwargs)
+        try:
+            response = completion(**completion_kwargs)
+        except RateLimitError as e:
+            raise RateLimitError(
+                message=(
+                    f"Rate limit exceeded for model '{self.llm_model}'. "
+                    "You have exceeded your API quota. "
+                    "Please wait a few minutes and try again, "
+                    "or switch to a different model. "
+                    "To check your quota visit: "
+                    "https://ai.google.dev/gemini-api/docs/rate-limits"
+                ),
+                llm_provider=self.llm_model.split("/")[0],
+                model=self.llm_model,
+            ) from e
 
         return response
 

--- a/tests/test_module_llm.py
+++ b/tests/test_module_llm.py
@@ -2,6 +2,7 @@ import os
 from unittest.mock import patch
 
 import pytest
+from litellm.exceptions import RateLimitError
 
 from mesa_llm.module_llm import ModuleLLM
 
@@ -108,6 +109,54 @@ class TestModuleLLM:
         )
         assert response is not None
 
+    def test_generate_rewrites_rate_limit_error_with_openai_docs(self, monkeypatch):
+        original_error = RateLimitError(
+            "per-minute limit hit", "openai", "openai/gpt-4o"
+        )
+
+        def _raise_rate_limit(**kwargs):
+            raise original_error
+
+        monkeypatch.setattr("mesa_llm.module_llm.completion", _raise_rate_limit)
+
+        llm = ModuleLLM(llm_model="openai/gpt-4o")
+        with pytest.raises(RateLimitError) as exc_info:
+            ModuleLLM.generate.__wrapped__(llm, prompt="Hello, how are you?")
+
+        assert str(exc_info.value) == (
+            "litellm.RateLimitError: Rate limit exceeded for model "
+            "'openai/gpt-4o'. per-minute limit hit Please wait a few minutes and "
+            "try again, or switch to a different model. To check your quota visit: "
+            "https://developers.openai.com/api/docs/guides/rate-limits"
+        )
+
+    def test_generate_rewrites_rate_limit_error_with_gemini_docs(self, monkeypatch):
+        original_error = RateLimitError(
+            'geminiException - {"error": {"code": 429}}',
+            "gemini",
+            "gemini/gemini-2.0-flash",
+            max_retries=5,
+            num_retries=3,
+        )
+
+        def _raise_rate_limit(**kwargs):
+            raise original_error
+
+        monkeypatch.setattr("mesa_llm.module_llm.completion", _raise_rate_limit)
+
+        llm = ModuleLLM(llm_model="gemini/gemini-2.0-flash")
+        with pytest.raises(RateLimitError) as exc_info:
+            ModuleLLM.generate.__wrapped__(llm, prompt="Hello, how are you?")
+
+        assert str(exc_info.value) == (
+            "litellm.RateLimitError: Rate limit exceeded for model "
+            '\'gemini/gemini-2.0-flash\'. geminiException - {"error": {"code": '
+            "429}} Please wait a few minutes and try again, or switch to a "
+            "different model. To check your quota visit: "
+            "https://ai.google.dev/gemini-api/docs/rate-limits LiteLLM Retried: "
+            "3 times, LiteLLM Max Retries: 5"
+        )
+
     @pytest.mark.asyncio
     async def test_agenerate(self, monkeypatch, llm_response_factory):
         async def _dummy_acompletion(**kwargs):
@@ -124,3 +173,49 @@ class TestModuleLLM:
             prompt=["Hello, how are you?", "What is the weather in Tokyo?"]
         )
         assert response is not None
+
+    @pytest.mark.asyncio
+    async def test_agenerate_rewrites_rate_limit_error_with_openrouter_docs(
+        self, monkeypatch
+    ):
+        class _SingleAttempt:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        class _SingleAsyncRetrying:
+            def __init__(self, **kwargs):
+                self._yielded = False
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self._yielded:
+                    raise StopAsyncIteration
+                self._yielded = True
+                return _SingleAttempt()
+
+        async def _raise_rate_limit(**kwargs):
+            raise RateLimitError(
+                "provider throttle triggered",
+                "openrouter",
+                "openrouter/openai/gpt-4o",
+            )
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test_openrouter_key")
+        monkeypatch.setattr("mesa_llm.module_llm.AsyncRetrying", _SingleAsyncRetrying)
+        monkeypatch.setattr("mesa_llm.module_llm.acompletion", _raise_rate_limit)
+
+        llm = ModuleLLM(llm_model="openrouter/openai/gpt-4o")
+        with pytest.raises(RateLimitError) as exc_info:
+            await llm.agenerate(prompt="Hello, how are you?")
+
+        assert str(exc_info.value) == (
+            "litellm.RateLimitError: Rate limit exceeded for model "
+            "'openrouter/openai/gpt-4o'. provider throttle triggered Please wait a "
+            "few minutes and try again, or switch to a different model. To check "
+            "your quota visit: https://openrouter.ai/docs/api/reference/limits"
+        )


### PR DESCRIPTION
Problem:
When a user exceeds their free  API quota while running a mesa-llm simulation, this library raises a raw LiteLLM exception that contains almost 100-200 lines of JSON. This makes it very difficult for new users to understand what went wrong or what to do next. I ran into this issue myself while running the negotiation example with a free Gemini API key.
What I changed:
In module_llm.py, I wrapped the completion() call inside 'generate()' and the acompletion() call inside agenerate() with a try/except block. When a RateLimitError is caught, instead of letting the raw exception propagate, it re raises with a clean human-readable message that tells the user their quota is exceeded, suggests waiting a few minutes or switching to a different model, and provides a direct link to check their API quota.
Before this fix:
litellm.RateLimitError: geminiException - {"error": {"code": 429 ... 200 lines of JSON
After this fix:
RateLimitError: Rate limit exceeded for model 'gemini/gemini-2.0-flash'. 
You have exceeded your API quota. Please wait a few minutes and try again, 
or switch to a different model. 
To check your quota visit: https://ai.google.dev/gemini-api/docs/rate-limits
Note:
Adding a proper unit test for this fix requires addressing the testability of the retry decorator in module_llm.py , current tenacity retry setup causes tests to hang. I have raised this as a separate concern.
