### PR TITLE
remove unused is_speaking attribute from LLMAgent

### DIFF
--- a/mesa_llm/llm_agent.py
+++ b/mesa_llm/llm_agent.py
@@ -63,7 +63,6 @@ class LLMAgent(Agent):
         self.vision = vision
         self.reasoning = reasoning(agent=self)
         self.system_prompt = system_prompt
-        self.is_speaking = False
         self._current_plan = None  # Store current plan for formatting
 
         # display coordination

--- a/mesa_llm/tools/inbuilt_tools.py
+++ b/mesa_llm/tools/inbuilt_tools.py
@@ -218,4 +218,4 @@ def speak_to(
                 ],
             },
         )
-    return f"{agent.unique_id} → {[agent.unique_id for agent in listener_agents]} : {message}"
+    return f"{agent.unique_id} → {[listener.unique_id for listener in listener_agents]} : {message}"


### PR DESCRIPTION
- Renamed loop variable in speak_to() that was shadowing the agent parameter
- Removed unused is_speaking attribute in LLMAgent