### PR TITLE
pin mesa below 4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 readme = "README.md"
 dependencies = [
-    "mesa[rec]>=3.0",
+    "mesa[rec]>=3.0,<4",
     "litellm",
     "python-dotenv",
     "terminal-style",


### PR DESCRIPTION
> [!NOTE]
> Use this template for bug fixes only. For enhancements/new features, use the feature template and get maintainer approval in an issue/discussion before opening a PR.

### Pre-PR Checklist
- [x] This PR is a bug fix, not a new feature or enhancement.

## Summary

Fixes #164.

### Bug / Issue

Mesa-LLM is not yet compatible with Mesa 4. The codebase still contains Mesa 4-breaking usage such as `mesa.space`, `model.steps`, and other API assumptions that are still being worked through in separate issues and PRs.

Without this fix, users can install Mesa 4 and hit import/runtime failures even though Mesa 4 support is not complete yet.

### Implementation

Pin Mesa to `<4` for now by changing the dependency from:

- `mesa[rec]>=3.0`

to:

- `mesa[rec]>=3.0,<4`

### Additional Notes

This PR does not add Mesa 4 support. It only prevents installation of an unsupported major version while the migration is coordinated separately.
