### PR TITLE
Fix: coerce numeric arguments in ToolManager

### DIFF
--- a/mesa_llm/tools/inbuilt_tools.py
+++ b/mesa_llm/tools/inbuilt_tools.py
@@ -208,8 +208,14 @@ def speak_to(
         try:
             listener_agents_unique_ids = json.loads(listener_agents_unique_ids)
         except (json.JSONDecodeError, ValueError):
-            listener_agents_unique_ids = [int(x.strip()) for x in listener_agents_unique_ids.strip("[]").split(",") if x.strip()]
-    listener_agents_unique_ids = [int(uid) for uid in (listener_agents_unique_ids or [])]
+            listener_agents_unique_ids = [
+                int(x.strip())
+                for x in listener_agents_unique_ids.strip("[]").split(",")
+                if x.strip()
+            ]
+    listener_agents_unique_ids = [
+        int(uid) for uid in (listener_agents_unique_ids or [])
+    ]
 
     listener_agents = [
         listener_agent

--- a/mesa_llm/tools/inbuilt_tools.py
+++ b/mesa_llm/tools/inbuilt_tools.py
@@ -203,6 +203,14 @@ def speak_to(
         listener_agents_unique_ids: The unique ids of the agents receiving the message
         message: The message to send
     """
+    if isinstance(listener_agents_unique_ids, str):
+        import json
+        try:
+            listener_agents_unique_ids = json.loads(listener_agents_unique_ids)
+        except (json.JSONDecodeError, ValueError):
+            listener_agents_unique_ids = [int(x.strip()) for x in listener_agents_unique_ids.strip("[]").split(",") if x.strip()]
+    listener_agents_unique_ids = [int(uid) for uid in (listener_agents_unique_ids or [])]
+
     listener_agents = [
         listener_agent
         for listener_agent in agent.model.agents

--- a/mesa_llm/tools/inbuilt_tools.py
+++ b/mesa_llm/tools/inbuilt_tools.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -204,7 +205,6 @@ def speak_to(
         message: The message to send
     """
     if isinstance(listener_agents_unique_ids, str):
-        import json
         try:
             listener_agents_unique_ids = json.loads(listener_agents_unique_ids)
         except (json.JSONDecodeError, ValueError):

--- a/mesa_llm/tools/tool_manager.py
+++ b/mesa_llm/tools/tool_manager.py
@@ -5,7 +5,7 @@ import inspect
 import json
 import logging
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, get_type_hints
 
 from terminal_style import style
 
@@ -127,7 +127,10 @@ class ToolManager:
             expects_agent = "agent" in sig.parameters
 
             # Filter arguments to only those accepted by the function, with type coercion based on annotations
-            hints = getattr(function_to_call, "__annotations__", {})
+            try:
+                hints = get_type_hints(function_to_call)
+            except (NameError, AttributeError, TypeError):
+                hints = getattr(function_to_call, "__annotations__", {})
 
             coerce: dict[type, type] = {float: float, int: int}
             filtered_args = {}

--- a/mesa_llm/tools/tool_manager.py
+++ b/mesa_llm/tools/tool_manager.py
@@ -127,10 +127,7 @@ class ToolManager:
             expects_agent = "agent" in sig.parameters
 
             # Filter arguments to only those accepted by the function, with type coercion based on annotations
-            try:
-                hints = function_to_call.__annotations__
-            except AttributeError:
-                hints = {}
+            hints = getattr(function_to_call, "__annotations__", {})
 
             coerce: dict[type, type] = {float: float, int: int}
             filtered_args = {}

--- a/mesa_llm/tools/tool_manager.py
+++ b/mesa_llm/tools/tool_manager.py
@@ -125,10 +125,25 @@ class ToolManager:
             sig = inspect.signature(function_to_call)
             expects_agent = "agent" in sig.parameters
 
-            # Filter arguments to only those accepted
-            filtered_args = {
-                k: v for k, v in function_args.items() if k in sig.parameters
-            }
+            # Filter arguments to only those accepted by the function, with type coercion based on annotations
+            try:
+                hints = function_to_call.__annotations__
+            except AttributeError:
+                hints = {}
+
+            _COERCE: dict[type, type] = {float: float, int: int}
+            filtered_args = {}
+            for k, v in function_args.items():
+                if k not in sig.parameters:
+                    continue
+                expected = hints.get(k)
+                coerce_fn = _COERCE.get(expected)
+                if coerce_fn is not None and not isinstance(v, expected):
+                    try:
+                        v = coerce_fn(v)
+                    except (ValueError, TypeError):
+                        pass 
+                filtered_args[k] = v
 
             if expects_agent:
                 filtered_args["agent"] = agent

--- a/mesa_llm/tools/tool_manager.py
+++ b/mesa_llm/tools/tool_manager.py
@@ -1,5 +1,6 @@
 import asyncio
 import concurrent.futures
+import contextlib
 import inspect
 import json
 import logging
@@ -131,19 +132,18 @@ class ToolManager:
             except AttributeError:
                 hints = {}
 
-            _COERCE: dict[type, type] = {float: float, int: int}
+            coerce: dict[type, type] = {float: float, int: int}
             filtered_args = {}
             for k, v in function_args.items():
                 if k not in sig.parameters:
                     continue
                 expected = hints.get(k)
-                coerce_fn = _COERCE.get(expected)
+                coerce_fn = coerce.get(expected)
+                new_value = v
                 if coerce_fn is not None and not isinstance(v, expected):
-                    try:
-                        v = coerce_fn(v)
-                    except (ValueError, TypeError):
-                        pass 
-                filtered_args[k] = v
+                    with contextlib.suppress(ValueError, TypeError):
+                        new_value = coerce_fn(v)
+                filtered_args[k] = new_value
 
             if expects_agent:
                 filtered_args["agent"] = agent

--- a/tests/test_tools/test_inbuilt_tools.py
+++ b/tests/test_tools/test_inbuilt_tools.py
@@ -213,6 +213,25 @@ def test_speak_to_parses_bracketed_string_ids(mocker):
     assert "hello" in ret and "[5, 6]" in ret
 
 
+def test_speak_to_parses_non_json_string_ids(mocker):
+    model = DummyModel()
+
+    sender = DummyAgent(unique_id=7, model=model)
+    r1 = DummyAgent(unique_id=8, model=model)
+    r2 = DummyAgent(unique_id=9, model=model)
+
+    r1.memory = SimpleNamespace(add_to_memory=mocker.Mock())
+    r2.memory = SimpleNamespace(add_to_memory=mocker.Mock())
+
+    model.agents = [sender, r1, r2]
+
+    ret = speak_to(sender, "8,9", "note")
+
+    r1.memory.add_to_memory.assert_called_once()
+    r2.memory.add_to_memory.assert_called_once()
+    assert "note" in ret and "[8, 9]" in ret
+
+
 def test_move_one_step_invalid_direction():
     model = DummyModel()
     model.grid = MultiGrid(width=4, height=4, torus=False)

--- a/tests/test_tools/test_inbuilt_tools.py
+++ b/tests/test_tools/test_inbuilt_tools.py
@@ -175,6 +175,44 @@ def test_speak_to_records_on_recipients(mocker):
     assert ret == "sent message 'Hello there' to [11, 12]"
 
 
+def test_speak_to_parses_json_string_ids(mocker):
+    model = DummyModel()
+
+    sender = DummyAgent(unique_id=1, model=model)
+    r1 = DummyAgent(unique_id=2, model=model)
+    r2 = DummyAgent(unique_id=3, model=model)
+
+    r1.memory = SimpleNamespace(add_to_memory=mocker.Mock())
+    r2.memory = SimpleNamespace(add_to_memory=mocker.Mock())
+
+    model.agents = [sender, r1, r2]
+
+    ret = speak_to(sender, "[2, 3]", "ping")
+
+    r1.memory.add_to_memory.assert_called_once()
+    r2.memory.add_to_memory.assert_called_once()
+    assert "ping" in ret and "[2, 3]" in ret
+
+
+def test_speak_to_parses_bracketed_string_ids(mocker):
+    model = DummyModel()
+
+    sender = DummyAgent(unique_id=4, model=model)
+    r1 = DummyAgent(unique_id=5, model=model)
+    r2 = DummyAgent(unique_id=6, model=model)
+
+    r1.memory = SimpleNamespace(add_to_memory=mocker.Mock())
+    r2.memory = SimpleNamespace(add_to_memory=mocker.Mock())
+
+    model.agents = [sender, r1, r2]
+
+    ret = speak_to(sender, "[5, 6]", "hello")
+
+    r1.memory.add_to_memory.assert_called_once()
+    r2.memory.add_to_memory.assert_called_once()
+    assert "hello" in ret and "[5, 6]" in ret
+
+
 def test_move_one_step_invalid_direction():
     model = DummyModel()
     model.grid = MultiGrid(width=4, height=4, torus=False)

--- a/tests/test_tools/test_tool_manager.py
+++ b/tests/test_tools/test_tool_manager.py
@@ -533,6 +533,37 @@ class TestToolManager:
         assert result[0]["tool_call_id"] == "call_float"
         assert result[0]["response"] == "35.00"
 
+    def test_call_tools_type_coercion_float_with_string_annotation(self):
+        """Test coercion when annotations are stored as strings."""
+        manager = ToolManager()
+
+        @tool
+        def float_tool(agent, amount: "float") -> "str":
+            """Float tool.
+            Args:
+                agent: The agent making the request
+                amount: Amount to format.
+            Returns:
+                Formatted amount.
+            """
+            return f"{amount:.2f}"
+
+        mock_agent = Mock()
+
+        mock_tool_call = Mock()
+        mock_tool_call.id = "call_float_string_annotation"
+        mock_tool_call.function.name = "float_tool"
+        mock_tool_call.function.arguments = '{"amount": "35.0"}'
+
+        mock_response = Mock()
+        mock_response.tool_calls = [mock_tool_call]
+
+        result = manager.call_tools(mock_agent, mock_response)
+
+        assert len(result) == 1
+        assert result[0]["tool_call_id"] == "call_float_string_annotation"
+        assert result[0]["response"] == "35.00"
+
     def test_call_tools_type_coercion_int(self):
         """Test coercion of int arguments passed as JSON strings."""
         manager = ToolManager()

--- a/tests/test_tools/test_tool_manager.py
+++ b/tests/test_tools/test_tool_manager.py
@@ -502,6 +502,68 @@ class TestToolManager:
         assert result[0]["tool_call_id"] == "call_123"
         assert "Simple: test" in result[0]["response"]
 
+    def test_call_tools_type_coercion_float(self):
+        """Test coercion of float arguments passed as JSON strings."""
+        manager = ToolManager()
+
+        @tool
+        def float_tool(agent, amount: float) -> str:
+            """Float tool.
+            Args:
+                agent: The agent making the request
+                amount: Amount to format.
+            Returns:
+                Formatted amount.
+            """
+            return f"{amount:.2f}"
+
+        mock_agent = Mock()
+
+        mock_tool_call = Mock()
+        mock_tool_call.id = "call_float"
+        mock_tool_call.function.name = "float_tool"
+        mock_tool_call.function.arguments = '{"amount": "35.0"}'
+
+        mock_response = Mock()
+        mock_response.tool_calls = [mock_tool_call]
+
+        result = manager.call_tools(mock_agent, mock_response)
+
+        assert len(result) == 1
+        assert result[0]["tool_call_id"] == "call_float"
+        assert result[0]["response"] == "35.00"
+
+    def test_call_tools_type_coercion_int(self):
+        """Test coercion of int arguments passed as JSON strings."""
+        manager = ToolManager()
+
+        @tool
+        def int_tool(agent, count: int) -> int:
+            """Int tool.
+            Args:
+                agent: The agent making the request
+                count: Count to increment.
+            Returns:
+                Incremented count.
+            """
+            return count + 1
+
+        mock_agent = Mock()
+
+        mock_tool_call = Mock()
+        mock_tool_call.id = "call_int"
+        mock_tool_call.function.name = "int_tool"
+        mock_tool_call.function.arguments = '{"count": "5"}'
+
+        mock_response = Mock()
+        mock_response.tool_calls = [mock_tool_call]
+
+        result = manager.call_tools(mock_agent, mock_response)
+
+        assert len(result) == 1
+        assert result[0]["tool_call_id"] == "call_int"
+        assert result[0]["response"] == "6"
+
     def test_call_tools_no_response(self):
         """Test call_tools when tool returns None."""
         manager = ToolManager()


### PR DESCRIPTION
### Pre-PR Checklist
- [T] This PR is a bug fix, not a new feature or enhancement.

### Summary
Fixes a bug where `ToolManager` passed numeric arguments as strings, causing tools annotated with `int`/`float` to fail. This impacted tool execution for LLMs that return numbers as JSON strings (e.g., Ollama).

`ToolManager` promises automatic type coercion in its docstring, but `_process_tool_call()` only filtered args by name. When an LLM returned `"35.0"` (string) for a `float` parameter, the tool received a string and raised an error. Expected behavior is to coerce to numeric types before invocation.

### Bug / Issue
Fixes #276 

### Implementation
- Added coercion in `_process_tool_call()` for `float` and `int` parameters.
- Added two regression tests in `tests/test_tools/test_tool_manager.py`:
  - string → float (`"35.0"` -> `35.0`)
  - string → int (`"5"` -> `5`)
### Testing
- `pytest tests/test_tools/test_tool_manager.py -v`

### Additional Notes
- Coercion is intentionally limited to `int` and `float` to avoid unintended conversions.
- If coercion fails (invalid value), the original input is passed through so tools still surface meaningful errors.
