### PR TITLE
Fix: Raises  value error for invalid tool name instead of key error 

### DIFF
--- a/mesa_llm/tools/tool_manager.py
+++ b/mesa_llm/tools/tool_manager.py
@@ -70,6 +70,17 @@ class ToolManager:
         self, selected_tools: list[str] | None = None
     ) -> list[dict]:
         if selected_tools:
+            invalid_tools = [tool for tool in selected_tools if tool not in self.tools]
+            if invalid_tools:
+                available_tools = sorted(self.tools.keys())
+                raise ValueError(
+                    style(
+                        "Unknown tool name(s): "
+                        f"{invalid_tools}. Available tools: {available_tools}",
+                        color="red",
+                    )
+                )
+
             selected_tools_schema = [
                 self.tools[tool].__tool_schema__ for tool in selected_tools
             ]

--- a/tests/test_tools/test_tool_manager.py
+++ b/tests/test_tools/test_tool_manager.py
@@ -288,7 +288,7 @@ class TestToolManager:
         # Test with nonexistent tools
         selected_tools = ["existing_tool", "nonexistent_tool"]
 
-        with pytest.raises(KeyError):
+        with pytest.raises(ValueError, match="Unknown tool name"):
             manager.get_all_tools_schema(selected_tools)
 
     def test_get_all_tools_schema_single_tool(self):


### PR DESCRIPTION
> [!NOTE]
> Use this template for bug fixes only. For enhancements/new features, use the feature template and get maintainer approval in an issue/discussion before opening a PR.

### Summary
ToolManager.get_all_tools_schema() currently raises a raw KeyError when selected_tools contains an unknown tool name. This leaks internal dictionary behavior to users and gives little guidance on how to fix the input.
This PR improves error handling by raising a clear ValueError that includes both invalid tool names and the list of available registered tools.

### Bug / Issue
Fixes : #279
### Context:

**Method**:  ToolManager.get_all_tools_schema(selected_tools=...)
**Expected** : actionable validation error for unknown tool names
**Actual** : low-level KeyError from dictionary lookup


### Impact:
Harder debugging for users configuring selected_tools
Poor DX in a core API path used by reasoning modules and custom tool pipelines

## Implementation
Updated get_all_tools_schema() in tool_manager.py to:

1 .Validate all selected_tools names against self.tools
2 . Collect unknown tool names
3 . Raise ValueError with:

-   unknown tool names
-   available tool names (sorted)

No behavior change for valid tool names.

Also updated test expectations in:

```
   test_tool_manager.py
```

   Specifically, the nonexistent tool case now expects ValueError (with message match) instead of KeyError.


## Testing
Executed targeted test suite for ToolManager:

``` bash

source .venv/bin/activate
pytest tests/test_tools/test_tool_manager.py -q
```

### Result:

All tests passed (28 passed)
Existing valid behavior is preserved
Nonexistent selected tool path now fails with explicit user-facing error as intended
