### PR TITLE
Add stock market example with LLM trader and analyst agents

### DIFF
--- a/examples/stock_market/agents.py
+++ b/examples/stock_market/agents.py
@@ -26,7 +26,9 @@ def get_trading_history(agent, max_messages: int = 5) -> str:
                     sender_name = f"{type(sender).__name__} {sender.unique_id}"
                 elif isinstance(sender, int):
                     try:
-                        agent_obj = next(a for a in agent.model.agents if a.unique_id == sender)
+                        agent_obj = next(
+                            a for a in agent.model.agents if a.unique_id == sender
+                        )
                         sender_name = f"{type(agent_obj).__name__} {sender}"
                     except StopIteration:
                         sender_name = f"Agent {sender}"
@@ -39,10 +41,26 @@ def get_trading_history(agent, max_messages: int = 5) -> str:
 
 
 class TraderAgent(LLMAgent):
-    def __init__(self, model, reasoning, llm_model, system_prompt, vision, internal_state, budget, api_base=None):
-        super().__init__(model=model, reasoning=reasoning, llm_model=llm_model,
-                         system_prompt=system_prompt, api_base=api_base,
-                         vision=vision, internal_state=internal_state)
+    def __init__(
+        self,
+        model,
+        reasoning,
+        llm_model,
+        system_prompt,
+        vision,
+        internal_state,
+        budget,
+        api_base=None,
+    ):
+        super().__init__(
+            model=model,
+            reasoning=reasoning,
+            llm_model=llm_model,
+            system_prompt=system_prompt,
+            api_base=api_base,
+            vision=vision,
+            internal_state=internal_state,
+        )
         self.tool_manager = trader_tool_manager
         self.budget = budget
         self.shares = 0
@@ -61,7 +79,9 @@ class TraderAgent(LLMAgent):
             f"RECENT ACTIVITY:\n{history}\n\n"
             "Use execute_trade to BUY, SELL, or HOLD. Justify briefly."
         )
-        plan = self.reasoning.plan(prompt=prompt, obs=observation, selected_tools=["execute_trade", "speak_to"])
+        plan = self.reasoning.plan(
+            prompt=prompt, obs=observation, selected_tools=["execute_trade", "speak_to"]
+        )
         self.apply_plan(plan)
 
     async def astep(self):
@@ -77,15 +97,32 @@ class TraderAgent(LLMAgent):
             f"RECENT ACTIVITY:\n{history}\n\n"
             "Use execute_trade to BUY, SELL, or HOLD. Justify briefly."
         )
-        plan = await self.reasoning.aplan(prompt=prompt, obs=observation, selected_tools=["execute_trade", "speak_to"])
+        plan = await self.reasoning.aplan(
+            prompt=prompt, obs=observation, selected_tools=["execute_trade", "speak_to"]
+        )
         self.apply_plan(plan)
 
 
 class AnalystAgent(LLMAgent):
-    def __init__(self, model, reasoning, llm_model, system_prompt, vision, internal_state, api_base=None):
-        super().__init__(model=model, reasoning=reasoning, llm_model=llm_model,
-                         system_prompt=system_prompt, api_base=api_base,
-                         vision=vision, internal_state=internal_state)
+    def __init__(
+        self,
+        model,
+        reasoning,
+        llm_model,
+        system_prompt,
+        vision,
+        internal_state,
+        api_base=None,
+    ):
+        super().__init__(
+            model=model,
+            reasoning=reasoning,
+            llm_model=llm_model,
+            system_prompt=system_prompt,
+            api_base=api_base,
+            vision=vision,
+            internal_state=internal_state,
+        )
         self.tool_manager = analyst_tool_manager
         self.recommendations_sent = 0
 
@@ -99,7 +136,9 @@ class AnalystAgent(LLMAgent):
             f"- Volatility: {self.model.volatility():.4f}\n\n"
             "Broadcast a BUY/HOLD/SELL signal with brief reasoning to nearby traders using speak_to."
         )
-        plan = self.reasoning.plan(prompt=prompt, obs=observation, selected_tools=["speak_to"])
+        plan = self.reasoning.plan(
+            prompt=prompt, obs=observation, selected_tools=["speak_to"]
+        )
         self.apply_plan(plan)
 
     async def astep(self):
@@ -112,5 +151,7 @@ class AnalystAgent(LLMAgent):
             f"- Volatility: {self.model.volatility():.4f}\n\n"
             "Broadcast a BUY/HOLD/SELL signal with brief reasoning to nearby traders using speak_to."
         )
-        plan = await self.reasoning.aplan(prompt=prompt, obs=observation, selected_tools=["speak_to"])
+        plan = await self.reasoning.aplan(
+            prompt=prompt, obs=observation, selected_tools=["speak_to"]
+        )
         self.apply_plan(plan)

--- a/examples/stock_market/agents.py
+++ b/examples/stock_market/agents.py
@@ -1,0 +1,116 @@
+import examples.stock_market.tools  # noqa: F401, to register tools
+from mesa_llm.llm_agent import LLMAgent
+from mesa_llm.tools.tool_manager import ToolManager
+
+trader_tool_manager = ToolManager()
+analyst_tool_manager = ToolManager()
+
+
+def get_trading_history(agent, max_messages: int = 5) -> str:
+    history = []
+    memory_source = None
+    if hasattr(agent.memory, "short_term_memory"):
+        memory_source = agent.memory.short_term_memory
+    elif hasattr(agent.memory, "memory_entries"):
+        memory_source = agent.memory.memory_entries
+
+    if memory_source:
+        entries_to_check = min(len(memory_source), max_messages * 2)
+        for entry in reversed(list(memory_source)[-entries_to_check:]):
+            if len(history) >= max_messages:
+                break
+            if isinstance(entry.content, dict) and "message" in entry.content:
+                sender = entry.content.get("sender", "Unknown")
+                msg = entry.content.get("message", "")
+                if hasattr(sender, "unique_id"):
+                    sender_name = f"{type(sender).__name__} {sender.unique_id}"
+                elif isinstance(sender, int):
+                    try:
+                        agent_obj = next(a for a in agent.model.agents if a.unique_id == sender)
+                        sender_name = f"{type(agent_obj).__name__} {sender}"
+                    except StopIteration:
+                        sender_name = f"Agent {sender}"
+                else:
+                    sender_name = str(sender)
+                history.append(f"- {sender_name}: {msg}")
+
+    history.reverse()
+    return "\n".join(history) if history else "No recent activity."
+
+
+class TraderAgent(LLMAgent):
+    def __init__(self, model, reasoning, llm_model, system_prompt, vision, internal_state, budget, api_base=None):
+        super().__init__(model=model, reasoning=reasoning, llm_model=llm_model,
+                         system_prompt=system_prompt, api_base=api_base,
+                         vision=vision, internal_state=internal_state)
+        self.tool_manager = trader_tool_manager
+        self.budget = budget
+        self.shares = 0
+        self.trades = 0
+
+    def step(self):
+        observation = self.generate_obs()
+        history = get_trading_history(self)
+        price = self.model.current_price
+        prompt = (
+            f"MARKET DATA:\n"
+            f"- Price: ${price:.2f}\n"
+            f"- Trend: {self.model.price_trend()}\n"
+            f"- RSI: {self.model.rsi():.1f} (>70 overbought, <30 oversold)\n"
+            f"- Budget: ${self.budget:.2f} | Shares: {self.shares}\n\n"
+            f"RECENT ACTIVITY:\n{history}\n\n"
+            "Use execute_trade to BUY, SELL, or HOLD. Justify briefly."
+        )
+        plan = self.reasoning.plan(prompt=prompt, obs=observation, selected_tools=["execute_trade", "speak_to"])
+        self.apply_plan(plan)
+
+    async def astep(self):
+        observation = self.generate_obs()
+        history = get_trading_history(self)
+        price = self.model.current_price
+        prompt = (
+            f"MARKET DATA:\n"
+            f"- Price: ${price:.2f}\n"
+            f"- Trend: {self.model.price_trend()}\n"
+            f"- RSI: {self.model.rsi():.1f} (>70 overbought, <30 oversold)\n"
+            f"- Budget: ${self.budget:.2f} | Shares: {self.shares}\n\n"
+            f"RECENT ACTIVITY:\n{history}\n\n"
+            "Use execute_trade to BUY, SELL, or HOLD. Justify briefly."
+        )
+        plan = await self.reasoning.aplan(prompt=prompt, obs=observation, selected_tools=["execute_trade", "speak_to"])
+        self.apply_plan(plan)
+
+
+class AnalystAgent(LLMAgent):
+    def __init__(self, model, reasoning, llm_model, system_prompt, vision, internal_state, api_base=None):
+        super().__init__(model=model, reasoning=reasoning, llm_model=llm_model,
+                         system_prompt=system_prompt, api_base=api_base,
+                         vision=vision, internal_state=internal_state)
+        self.tool_manager = analyst_tool_manager
+        self.recommendations_sent = 0
+
+    def step(self):
+        observation = self.generate_obs()
+        prompt = (
+            f"MARKET SUMMARY:\n"
+            f"- Price: ${self.model.current_price:.2f}\n"
+            f"- Trend: {self.model.price_trend()}\n"
+            f"- RSI: {self.model.rsi():.1f}\n"
+            f"- Volatility: {self.model.volatility():.4f}\n\n"
+            "Broadcast a BUY/HOLD/SELL signal with brief reasoning to nearby traders using speak_to."
+        )
+        plan = self.reasoning.plan(prompt=prompt, obs=observation, selected_tools=["speak_to"])
+        self.apply_plan(plan)
+
+    async def astep(self):
+        observation = self.generate_obs()
+        prompt = (
+            f"MARKET SUMMARY:\n"
+            f"- Price: ${self.model.current_price:.2f}\n"
+            f"- Trend: {self.model.price_trend()}\n"
+            f"- RSI: {self.model.rsi():.1f}\n"
+            f"- Volatility: {self.model.volatility():.4f}\n\n"
+            "Broadcast a BUY/HOLD/SELL signal with brief reasoning to nearby traders using speak_to."
+        )
+        plan = await self.reasoning.aplan(prompt=prompt, obs=observation, selected_tools=["speak_to"])
+        self.apply_plan(plan)

--- a/examples/stock_market/app.py
+++ b/examples/stock_market/app.py
@@ -64,7 +64,11 @@ if __name__ == "__main__":
     def MarketStatsPanel(*args, **kwargs):
         show = solara.use_reactive(False)
         df = solara.use_memo(
-            lambda: model.datacollector.get_model_vars_dataframe() if show.value else pd.DataFrame(),
+            lambda: (
+                model.datacollector.get_model_vars_dataframe()
+                if show.value
+                else pd.DataFrame()
+            ),
             [show.value],
         )
         solara.Button(label="Show Market Data", on_click=lambda: show.set(True))

--- a/examples/stock_market/app.py
+++ b/examples/stock_market/app.py
@@ -1,0 +1,84 @@
+import logging
+import warnings
+
+import pandas as pd
+import solara
+from dotenv import load_dotenv
+from mesa.visualization import SolaraViz, make_space_component
+
+import examples.stock_market.tools  # noqa: F401, registers tools
+from examples.stock_market.agents import AnalystAgent, TraderAgent
+from examples.stock_market.model import StockMarketModel
+from mesa_llm.parallel_stepping import enable_automatic_parallel_stepping
+from mesa_llm.reasoning.react import ReActReasoning
+
+warnings.filterwarnings("ignore", category=UserWarning, module="pydantic.main")
+logging.getLogger("pydantic").setLevel(logging.ERROR)
+
+enable_automatic_parallel_stepping(mode="threading")
+load_dotenv()
+
+model_params = {
+    "seed": {"type": "InputText", "value": 42, "label": "Random Seed"},
+    "initial_traders": 4,
+    "n_analysts": 2,
+    "width": 5,
+    "height": 5,
+    "reasoning": ReActReasoning,
+    "llm_model": "openai/gpt-4o",
+    "vision": 3,
+    "initial_price": 100.0,
+    "api_base": None,
+}
+
+model = StockMarketModel(
+    initial_traders=model_params["initial_traders"],
+    n_analysts=model_params["n_analysts"],
+    width=model_params["width"],
+    height=model_params["height"],
+    reasoning=model_params["reasoning"],
+    llm_model=model_params["llm_model"],
+    vision=model_params["vision"],
+    initial_price=model_params["initial_price"],
+    api_base=model_params["api_base"],
+    seed=model_params["seed"]["value"],
+)
+
+if __name__ == "__main__":
+
+    def model_portrayal(agent):
+        if agent is None:
+            return
+        portrayal = {"size": 25}
+        if isinstance(agent, AnalystAgent):
+            portrayal["color"] = "tab:orange"
+            portrayal["marker"] = "D"
+            portrayal["zorder"] = 3
+        elif isinstance(agent, TraderAgent):
+            portrayal["color"] = "tab:green" if agent.budget > 500.0 else "tab:red"
+            portrayal["marker"] = "o"
+            portrayal["zorder"] = 2
+        return portrayal
+
+    @solara.component
+    def MarketStatsPanel(*args, **kwargs):
+        show = solara.use_reactive(False)
+        df = solara.use_memo(
+            lambda: model.datacollector.get_model_vars_dataframe() if show.value else pd.DataFrame(),
+            [show.value],
+        )
+        solara.Button(label="Show Market Data", on_click=lambda: show.set(True))
+        if show.value and not df.empty:
+            solara.DataFrame(df)
+
+    page = SolaraViz(
+        model,
+        components=[make_space_component(model_portrayal), MarketStatsPanel],
+        model_params=model_params,
+        name="Stock Market",
+    )
+
+"""
+Run with:
+conda activate mesa-llm && solara run examples/stock_market/app.py
+"""

--- a/examples/stock_market/model.py
+++ b/examples/stock_market/model.py
@@ -7,7 +7,6 @@ from mesa.space import MultiGrid
 from rich import print
 
 from examples.stock_market.agents import AnalystAgent, TraderAgent
-from mesa_llm.reasoning.reasoning import Reasoning
 
 
 class StockMarketModel(Model):
@@ -28,9 +27,19 @@ class StockMarketModel(Model):
         seed: Random seed.
     """
 
-    def __init__(self, initial_traders, n_analysts, width, height,
-                 reasoning, llm_model, vision, initial_price=100.0,
-                 api_base=None, seed=None):
+    def __init__(
+        self,
+        initial_traders,
+        n_analysts,
+        width,
+        height,
+        reasoning,
+        llm_model,
+        vision,
+        initial_price=100.0,
+        api_base=None,
+        seed=None,
+    ):
         super().__init__(seed=seed)
         self.width = width
         self.height = height
@@ -40,9 +49,14 @@ class StockMarketModel(Model):
 
         # Analyst agents
         analysts = AnalystAgent.create_agents(
-            self, n=n_analysts, reasoning=reasoning, llm_model=llm_model,
+            self,
+            n=n_analysts,
+            reasoning=reasoning,
+            llm_model=llm_model,
             system_prompt="You are a quantitative market analyst. Observe price trends, RSI, and volatility. Send clear BUY, HOLD, or SELL signals to nearby traders. Be concise and data-driven.",
-            vision=vision, internal_state=["analytical", "data-driven", "calm"], api_base=api_base,
+            vision=vision,
+            internal_state=["analytical", "data-driven", "calm"],
+            api_base=api_base,
         )
         ax = self.rng.integers(0, self.grid.width, size=(n_analysts,))
         ay = self.rng.integers(0, self.grid.height, size=(n_analysts,))
@@ -52,10 +66,15 @@ class StockMarketModel(Model):
         # Conservative traders
         n_conservative = math.ceil(initial_traders / 2)
         conservative = TraderAgent.create_agents(
-            self, n=n_conservative, reasoning=reasoning, llm_model=llm_model,
+            self,
+            n=n_conservative,
+            reasoning=reasoning,
+            llm_model=llm_model,
             system_prompt="You are a conservative trader. Only buy when RSI is below 35 and trend is rising. Sell quickly if you sense risk. Protect capital above all else.",
-            vision=vision, internal_state=["risk-averse", "patient", "disciplined"],
-            budget=500.0, api_base=api_base,
+            vision=vision,
+            internal_state=["risk-averse", "patient", "disciplined"],
+            budget=500.0,
+            api_base=api_base,
         )
         cx = self.rng.integers(0, self.grid.width, size=(n_conservative,))
         cy = self.rng.integers(0, self.grid.height, size=(n_conservative,))
@@ -65,10 +84,15 @@ class StockMarketModel(Model):
         # Aggressive traders
         n_aggressive = math.floor(initial_traders / 2)
         aggressive = TraderAgent.create_agents(
-            self, n=n_aggressive, reasoning=reasoning, llm_model=llm_model,
+            self,
+            n=n_aggressive,
+            reasoning=reasoning,
+            llm_model=llm_model,
             system_prompt="You are an aggressive momentum trader. Buy when price is rising, sell fast to lock in gains. Act quickly on analyst signals. Maximize profit.",
-            vision=vision, internal_state=["risk-tolerant", "fast", "opportunistic"],
-            budget=500.0, api_base=api_base,
+            vision=vision,
+            internal_state=["risk-tolerant", "fast", "opportunistic"],
+            budget=500.0,
+            api_base=api_base,
         )
         agx = self.rng.integers(0, self.grid.width, size=(n_aggressive,))
         agy = self.rng.integers(0, self.grid.height, size=(n_aggressive,))
@@ -78,9 +102,12 @@ class StockMarketModel(Model):
         self.datacollector = DataCollector(
             model_reporters={
                 "Stock_Price": lambda m: round(m.current_price, 2),
-                "Total_Trades": lambda m: sum(a.trades for a in m.agents if isinstance(a, TraderAgent)),
+                "Total_Trades": lambda m: sum(
+                    a.trades for a in m.agents if isinstance(a, TraderAgent)
+                ),
                 "Avg_Trader_Budget": lambda m: round(
-                    np.mean([a.budget for a in m.agents if isinstance(a, TraderAgent)]), 2
+                    np.mean([a.budget for a in m.agents if isinstance(a, TraderAgent)]),
+                    2,
                 ),
             }
         )
@@ -102,7 +129,7 @@ class StockMarketModel(Model):
     def rsi(self, period: int = 6) -> float:
         if len(self.price_history) < period + 1:
             return 50.0
-        deltas = np.diff(self.price_history[-period - 1:])
+        deltas = np.diff(self.price_history[-period - 1 :])
         gains = deltas[deltas > 0].sum()
         losses = abs(deltas[deltas < 0].sum())
         if losses == 0:
@@ -134,5 +161,6 @@ class StockMarketModel(Model):
 
 if __name__ == "__main__":
     from examples.stock_market.app import model
+
     for _ in range(10):
         model.step()

--- a/examples/stock_market/model.py
+++ b/examples/stock_market/model.py
@@ -1,0 +1,138 @@
+import math
+
+import numpy as np
+from mesa.datacollection import DataCollector
+from mesa.model import Model
+from mesa.space import MultiGrid
+from rich import print
+
+from examples.stock_market.agents import AnalystAgent, TraderAgent
+from mesa_llm.reasoning.reasoning import Reasoning
+
+
+class StockMarketModel(Model):
+    """
+    A stock market simulation where LLM-powered trader agents buy and sell
+    shares based on price data and analyst signals.
+
+    Args:
+        initial_traders (int): Number of trader agents.
+        n_analysts (int): Number of analyst agents.
+        width (int): Grid width.
+        height (int): Grid height.
+        reasoning: Reasoning class for all agents.
+        llm_model (str): LiteLLM model string e.g. "openai/gpt-4o".
+        vision (int): Agent observation radius.
+        initial_price (float): Starting stock price.
+        api_base (str | None): Optional custom API base URL.
+        seed: Random seed.
+    """
+
+    def __init__(self, initial_traders, n_analysts, width, height,
+                 reasoning, llm_model, vision, initial_price=100.0,
+                 api_base=None, seed=None):
+        super().__init__(seed=seed)
+        self.width = width
+        self.height = height
+        self.current_price = initial_price
+        self.price_history = [initial_price]
+        self.grid = MultiGrid(self.height, self.width, torus=False)
+
+        # Analyst agents
+        analysts = AnalystAgent.create_agents(
+            self, n=n_analysts, reasoning=reasoning, llm_model=llm_model,
+            system_prompt="You are a quantitative market analyst. Observe price trends, RSI, and volatility. Send clear BUY, HOLD, or SELL signals to nearby traders. Be concise and data-driven.",
+            vision=vision, internal_state=["analytical", "data-driven", "calm"], api_base=api_base,
+        )
+        ax = self.rng.integers(0, self.grid.width, size=(n_analysts,))
+        ay = self.rng.integers(0, self.grid.height, size=(n_analysts,))
+        for a, i, j in zip(analysts, ax, ay):
+            self.grid.place_agent(a, (i, j))
+
+        # Conservative traders
+        n_conservative = math.ceil(initial_traders / 2)
+        conservative = TraderAgent.create_agents(
+            self, n=n_conservative, reasoning=reasoning, llm_model=llm_model,
+            system_prompt="You are a conservative trader. Only buy when RSI is below 35 and trend is rising. Sell quickly if you sense risk. Protect capital above all else.",
+            vision=vision, internal_state=["risk-averse", "patient", "disciplined"],
+            budget=500.0, api_base=api_base,
+        )
+        cx = self.rng.integers(0, self.grid.width, size=(n_conservative,))
+        cy = self.rng.integers(0, self.grid.height, size=(n_conservative,))
+        for a, i, j in zip(conservative, cx, cy):
+            self.grid.place_agent(a, (i, j))
+
+        # Aggressive traders
+        n_aggressive = math.floor(initial_traders / 2)
+        aggressive = TraderAgent.create_agents(
+            self, n=n_aggressive, reasoning=reasoning, llm_model=llm_model,
+            system_prompt="You are an aggressive momentum trader. Buy when price is rising, sell fast to lock in gains. Act quickly on analyst signals. Maximize profit.",
+            vision=vision, internal_state=["risk-tolerant", "fast", "opportunistic"],
+            budget=500.0, api_base=api_base,
+        )
+        agx = self.rng.integers(0, self.grid.width, size=(n_aggressive,))
+        agy = self.rng.integers(0, self.grid.height, size=(n_aggressive,))
+        for a, i, j in zip(aggressive, agx, agy):
+            self.grid.place_agent(a, (i, j))
+
+        self.datacollector = DataCollector(
+            model_reporters={
+                "Stock_Price": lambda m: round(m.current_price, 2),
+                "Total_Trades": lambda m: sum(a.trades for a in m.agents if isinstance(a, TraderAgent)),
+                "Avg_Trader_Budget": lambda m: round(
+                    np.mean([a.budget for a in m.agents if isinstance(a, TraderAgent)]), 2
+                ),
+            }
+        )
+
+    def price_trend(self) -> str:
+        if len(self.price_history) < 3:
+            return "insufficient data"
+        delta = self.price_history[-1] - self.price_history[-3]
+        if delta > 1.5:
+            return f"strongly rising (+${delta:.2f})"
+        elif delta > 0:
+            return f"slightly rising (+${delta:.2f})"
+        elif delta < -1.5:
+            return f"strongly falling (-${abs(delta):.2f})"
+        elif delta < 0:
+            return f"slightly falling (-${abs(delta):.2f})"
+        return "flat"
+
+    def rsi(self, period: int = 6) -> float:
+        if len(self.price_history) < period + 1:
+            return 50.0
+        deltas = np.diff(self.price_history[-period - 1:])
+        gains = deltas[deltas > 0].sum()
+        losses = abs(deltas[deltas < 0].sum())
+        if losses == 0:
+            return 100.0
+        return round(100 - (100 / (1 + gains / losses)), 2)
+
+    def volatility(self, window: int = 10) -> float:
+        if len(self.price_history) < 2:
+            return 0.0
+        prices = np.array(self.price_history[-window:])
+        return round(float(np.std(np.diff(np.log(prices)))), 4)
+
+    def _update_price(self):
+        shock = self.rng.normal(0, 0.015)
+        mean_reversion = 0.01 * (100.0 - self.current_price) / 100.0
+        self.current_price *= 1 + shock + mean_reversion
+        self.current_price = max(self.current_price, 1.0)
+        self.price_history.append(round(self.current_price, 4))
+
+    def step(self):
+        self._update_price()
+        self.datacollector.collect(self)
+        print(
+            f"\n[bold cyan] step {self.steps} | price ${self.current_price:.2f} "
+            f"| RSI {self.rsi():.1f} | {self.price_trend()} ────────────────[/bold cyan]"
+        )
+        self.agents.shuffle_do("step")
+
+
+if __name__ == "__main__":
+    from examples.stock_market.app import model
+    for _ in range(10):
+        model.step()

--- a/examples/stock_market/tools.py
+++ b/examples/stock_market/tools.py
@@ -1,0 +1,61 @@
+from typing import TYPE_CHECKING
+
+from examples.stock_market.agents import trader_tool_manager
+from mesa_llm.tools.tool_decorator import tool
+
+if TYPE_CHECKING:
+    from mesa_llm.llm_agent import LLMAgent
+
+
+@tool(tool_manager=trader_tool_manager)
+def execute_trade(agent: "LLMAgent", action: str, quantity: int = 1) -> str:
+    """
+    Execute a stock trade on behalf of a trader agent.
+
+    Args:
+        agent: The trader agent executing the trade.
+        action: One of "BUY", "SELL", or "HOLD".
+        quantity: Number of shares to buy or sell (default: 1).
+
+    Returns:
+        str: A summary of the trade outcome.
+    """
+    action = action.upper().strip()
+    if action not in {"BUY", "SELL", "HOLD"}:
+        raise ValueError(f"Invalid action '{action}'. Must be BUY, SELL, or HOLD.")
+
+    price = agent.model.current_price
+
+    if action == "BUY":
+        total_cost = price * quantity
+        if agent.budget < total_cost:
+            return (
+                f"Cannot BUY {quantity} share(s) at ${price:.2f} each "
+                f"(total ${total_cost:.2f}). Insufficient budget: ${agent.budget:.2f}."
+            )
+        agent.budget -= total_cost
+        agent.shares += quantity
+        agent.trades += 1
+        return (
+            f"Bought {quantity} share(s) at ${price:.2f}. "
+            f"Spent: ${total_cost:.2f}. Budget: ${agent.budget:.2f}. Shares: {agent.shares}."
+        )
+
+    elif action == "SELL":
+        if agent.shares < quantity:
+            return f"Cannot SELL {quantity} share(s). Only holding {agent.shares}."
+        proceeds = price * quantity
+        agent.shares -= quantity
+        agent.budget += proceeds
+        agent.trades += 1
+        return (
+            f"Sold {quantity} share(s) at ${price:.2f}. "
+            f"Proceeds: ${proceeds:.2f}. Budget: ${agent.budget:.2f}. Shares: {agent.shares}."
+        )
+
+    else:
+        return (
+            f"Holding. Price: ${price:.2f}. "
+            f"Shares: {agent.shares} (value: ${agent.shares * price:.2f}). "
+            f"Budget: ${agent.budget:.2f}."
+        )


### PR DESCRIPTION
This PR adds a stock market simulation example to mesa-llm, demonstrating 
LLM-powered agents reasoning over quantitative financial data.



TraderAgent — uses ReAct reasoning to decide BUY/SELL/HOLD based on 
  live price, RSI, and trend data. Two archetypes: conservative and aggressive.
AnalystAgent— reads market indicators and broadcasts signals to nearby 
  traders via speak_to.
execute_trade tool — handles buy/sell/hold logic with budget and share tracking.
StockMarketModel — simulates price movement with random walk + mean 
  reversion, computes RSI and volatility, collects data via DataCollector.
Solara visualization — color-coded agents (green = profitable, red = loss).

 Testing

Follows the same structure as the negotiation example. Compatible with any 
LiteLLM provider (OpenAI, Anthropic, Ollama).

@colinfrisch @jackiekazil happy to adjust anything based on your feedback!