### PR TITLE
Fix: Correctly raised value error with descriptive error message in case of Invalid model instead of not a function calling model 

### DIFF
--- a/mesa_llm/module_llm.py
+++ b/mesa_llm/module_llm.py
@@ -5,6 +5,7 @@ from dotenv import load_dotenv
 from litellm import acompletion, completion, litellm
 from litellm.exceptions import (
     APIConnectionError,
+    NotFoundError,
     RateLimitError,
     Timeout,
 )
@@ -73,21 +74,29 @@ class ModuleLLM:
                     f"No API key found for {provider}. Please set the {provider}_API_KEY environment variable (e.g., in your .env file)."
                 ) from err
 
-            try:
-                litellm.get_model_info(model=self.llm_model)
-            except Exception as e:
-                raise ValueError(
-                    f"Invalid or unsupported model '{self.llm_model}' for provider "
-                    f"'{provider.lower()}'. Details: {e}. "
-                    "Please verify the model name and provider prefix, and if you are "
-                    f"using a custom endpoint set the correct api_base (current: {self.api_base})."
-                ) from e
-
-        if not litellm.supports_function_calling(model=self.llm_model):
-            logger.warning(
-                "%s does not support function calling. This model may not be able to use tools. Please check the model documentation at https://docs.litellm.ai/docs/providers for more information.",
+        try:
+            litellm.get_model_info(model=self.llm_model)
+        except Exception as exc:
+            logger.debug(
+                "Skipping function-calling capability check for unmapped model %s: %s",
                 self.llm_model,
+                exc,
             )
+        else:
+            if not litellm.supports_function_calling(model=self.llm_model):
+                logger.warning(
+                    "%s does not support function calling. This model may not be able to use tools. Please check the model documentation at https://docs.litellm.ai/docs/providers for more information.",
+                    self.llm_model,
+                )
+
+    def _build_invalid_model_error(self, error: Exception) -> ValueError:
+        provider = self.llm_model.split("/", 1)[0].lower()
+        return ValueError(
+            f"Invalid or unsupported model '{self.llm_model}' for provider "
+            f"'{provider}'. Details: {error}. "
+            "Please verify the model name and provider prefix, and if you are "
+            f"using a custom endpoint set the correct api_base (current: {self.api_base})."
+        )
 
     def _build_messages(self, prompt: str | list[str] | None = None) -> list[dict]:
         """
@@ -187,6 +196,12 @@ class ModuleLLM:
             response = completion(**completion_kwargs)
         except RateLimitError as error:
             raise self._build_rate_limit_error(error) from error
+        except NotFoundError as error:
+            raise self._build_invalid_model_error(error) from error
+        except Exception as error:
+            if str(error).startswith("This model isn't mapped yet."):
+                raise self._build_invalid_model_error(error) from error
+            raise
 
         return response
 
@@ -221,4 +236,10 @@ class ModuleLLM:
                     response = await acompletion(**completion_kwargs)
                 except RateLimitError as error:
                     raise self._build_rate_limit_error(error) from error
+                except NotFoundError as error:
+                    raise self._build_invalid_model_error(error) from error
+                except Exception as error:
+                    if str(error).startswith("This model isn't mapped yet."):
+                        raise self._build_invalid_model_error(error) from error
+                    raise
         return response

--- a/mesa_llm/module_llm.py
+++ b/mesa_llm/module_llm.py
@@ -73,6 +73,16 @@ class ModuleLLM:
                     f"No API key found for {provider}. Please set the {provider}_API_KEY environment variable (e.g., in your .env file)."
                 ) from err
 
+            try:
+                litellm.get_model_info(model=self.llm_model)
+            except Exception as e:
+                raise ValueError(
+                    f"Invalid or unsupported model '{self.llm_model}' for provider "
+                    f"'{provider.lower()}'. Details: {e}. "
+                    "Please verify the model name and provider prefix, and if you are "
+                    f"using a custom endpoint set the correct api_base (current: {self.api_base})."
+                ) from e
+
         if not litellm.supports_function_calling(model=self.llm_model):
             logger.warning(
                 "%s does not support function calling. This model may not be able to use tools. Please check the model documentation at https://docs.litellm.ai/docs/providers for more information.",

--- a/tests/test_module_llm.py
+++ b/tests/test_module_llm.py
@@ -10,6 +10,14 @@ from mesa_llm.module_llm import ModuleLLM
 class TestModuleLLM:
     """Test ModuleLLM class"""
 
+    @pytest.fixture(autouse=True)
+    def _mock_model_catalog_checks(self, monkeypatch):
+        """Keep model validation deterministic in unit tests."""
+
+        monkeypatch.setattr(
+            "mesa_llm.module_llm.litellm.get_model_info", lambda model: {}
+        )
+
     def test_missing_provider_prefix(self):
         """ModuleLLM should raise ValueError when llm_model has no provider prefix."""
         with pytest.raises(ValueError, match="Invalid model format"):
@@ -83,10 +91,37 @@ class TestModuleLLM:
         messages = llm._build_messages(prompt=None)
         assert messages == [{"role": "system", "content": ""}]
 
+    def test_model_name_validity(self):
+        # Test initialization with invalid model format
+
+        with pytest.raises(ValueError, match="Invalid model format"):
+            ModuleLLM(llm_model="gpt-4o")
+
+        llm = ModuleLLM(llm_model="openai/gpt-4o")
+        assert llm.llm_model == "openai/gpt-4o"
+
+        llm = ModuleLLM(llm_model="ollama/llama2")
+        assert llm.llm_model == "ollama/llama2"
+
+    def test_invalid_model_name_has_descriptive_error(self, monkeypatch):
+        def _raise_unmapped(model):
+            raise Exception("This model isn't mapped yet")
+
+        monkeypatch.setattr(
+            "mesa_llm.module_llm.litellm.get_model_info", _raise_unmapped
+        )
+
+        with pytest.raises(ValueError, match="Invalid or unsupported model"):
+            ModuleLLM(llm_model="openai/not-a-real-model")
+
+        with pytest.raises(ValueError, match="Invalid or unsupported model"):
+            ModuleLLM(llm_model="openai/get-4o")
+
     def test_generate(self, monkeypatch, llm_response_factory):
         monkeypatch.setattr(
             "mesa_llm.module_llm.completion", lambda **kwargs: llm_response_factory()
         )
+
         # Test generate with string prompt
         llm = ModuleLLM(llm_model="openai/gpt-4o")
         response = llm.generate(prompt="Hello, how are you?")

--- a/tests/test_module_llm.py
+++ b/tests/test_module_llm.py
@@ -1,8 +1,9 @@
+import logging
 import os
 from unittest.mock import patch
 
 import pytest
-from litellm.exceptions import RateLimitError
+from litellm.exceptions import NotFoundError, RateLimitError
 
 from mesa_llm.module_llm import ModuleLLM
 
@@ -103,19 +104,60 @@ class TestModuleLLM:
         llm = ModuleLLM(llm_model="ollama/llama2")
         assert llm.llm_model == "ollama/llama2"
 
-    def test_invalid_model_name_has_descriptive_error(self, monkeypatch):
+    def test_custom_api_base_allows_unmapped_model(self, monkeypatch, caplog):
         def _raise_unmapped(model):
             raise Exception("This model isn't mapped yet")
 
         monkeypatch.setattr(
             "mesa_llm.module_llm.litellm.get_model_info", _raise_unmapped
         )
+        monkeypatch.setattr(
+            "mesa_llm.module_llm.litellm.supports_function_calling",
+            lambda model: pytest.fail(
+                "supports_function_calling should not run for unmapped models"
+            ),
+        )
+
+        with caplog.at_level(logging.WARNING):
+            llm = ModuleLLM(
+                llm_model="openai/my-local-model",
+                api_base="http://localhost:1234/v1",
+            )
+
+        assert llm.llm_model == "openai/my-local-model"
+        assert llm.api_base == "http://localhost:1234/v1"
+        assert "does not support function calling" not in caplog.text
+
+    def test_generate_invalid_model_name_has_descriptive_error(self, monkeypatch):
+        monkeypatch.setattr(
+            "mesa_llm.module_llm.completion",
+            lambda **kwargs: (_ for _ in ()).throw(
+                NotFoundError(
+                    message="OpenAIException - model_not_found",
+                    model="openai/not-a-real-model",
+                    llm_provider="openai",
+                )
+            ),
+        )
+
+        llm = ModuleLLM(llm_model="openai/not-a-real-model")
 
         with pytest.raises(ValueError, match="Invalid or unsupported model"):
-            ModuleLLM(llm_model="openai/not-a-real-model")
+            ModuleLLM.generate.__wrapped__(llm, prompt="Hello, how are you?")
 
-        with pytest.raises(ValueError, match="Invalid or unsupported model"):
-            ModuleLLM(llm_model="openai/get-4o")
+    def test_mapped_model_without_function_calling_warns(self, monkeypatch, caplog):
+        monkeypatch.setattr(
+            "mesa_llm.module_llm.litellm.get_model_info", lambda model: {}
+        )
+        monkeypatch.setattr(
+            "mesa_llm.module_llm.litellm.supports_function_calling",
+            lambda model: False,
+        )
+
+        with caplog.at_level(logging.WARNING):
+            ModuleLLM(llm_model="openai/gpt-4o")
+
+        assert "does not support function calling" in caplog.text
 
     def test_generate(self, monkeypatch, llm_response_factory):
         monkeypatch.setattr(
@@ -254,3 +296,42 @@ class TestModuleLLM:
             "few minutes and try again, or switch to a different model. To check "
             "your quota visit: https://openrouter.ai/docs/api/reference/limits"
         )
+
+    @pytest.mark.asyncio
+    async def test_agenerate_invalid_model_name_has_descriptive_error(
+        self, monkeypatch
+    ):
+        class _SingleAttempt:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        class _SingleAsyncRetrying:
+            def __init__(self, **kwargs):
+                self._yielded = False
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self._yielded:
+                    raise StopAsyncIteration
+                self._yielded = True
+                return _SingleAttempt()
+
+        async def _raise_invalid_model(**kwargs):
+            raise Exception(
+                "This model isn't mapped yet. model=openai/not-a-real-model, "
+                "custom_llm_provider=openai. Add it here - "
+                "https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json."
+            )
+
+        monkeypatch.setattr("mesa_llm.module_llm.AsyncRetrying", _SingleAsyncRetrying)
+        monkeypatch.setattr("mesa_llm.module_llm.acompletion", _raise_invalid_model)
+
+        llm = ModuleLLM(llm_model="openai/not-a-real-model")
+
+        with pytest.raises(ValueError, match="Invalid or unsupported model"):
+            await llm.agenerate(prompt="Hello, how are you?")


### PR DESCRIPTION
> [!NOTE]
> Use this template for bug fixes only. For enhancements/new features, use the feature template and get maintainer approval in an issue/discussion before opening a PR.

### Pre-PR Checklist
- [x] This PR is a bug fix, not a new feature or enhancement.

### Summary
<!-- Provide a brief summary of the bug and its impact. -->

 When given an invalid model name it throws Error with message not a function calling model it might trick user in thinking their model is valid but not function calling and does'nt address actual model invalid issue 

### Bug / Issue
<!-- Link to the related issue(s) and describe the bug. Include details like the context, what was expected, and what actually happened. -->
Fix : #284 

### Implementation
<!-- Describe the changes made to resolve the issue. Highlight any important parts of the code that were modified. -->
I added an model validity check right after api key check i used 

```
litellm.get_model_info() 
```

wrapped in try and except block and raise ValueError when caught an error and show a descriptive message 



### Testing
<!-- Detail the testing performed to verify the fix. Include information on test cases, steps taken, and any relevant results.

I have added necessary tests 
in test_module_llm.py

If you're fixing the visualization, add before/after screenshots. -->

### Additional Notes
<!-- Add any additional information that may be relevant for the reviewers, such as potential side effects, dependencies, or related work.
Unit tests mock model-catalog checks for determinism; i
-->
