### PR TITLE
fix: change executor tool_choice from required to auto so reasoning respects no-action decisions

### DIFF
--- a/mesa_llm/reasoning/cot.py
+++ b/mesa_llm/reasoning/cot.py
@@ -130,12 +130,15 @@ class CoTReasoning(Reasoning):
         # Pass plan content to agent for display
         if hasattr(self.agent, "_step_display_data"):
             self.agent._step_display_data["plan_content"] = chaining_message
-        system_prompt = "You are an executor that executes the plan given to you in the prompt through tool calls."
+        system_prompt = (
+            "You are an executor that executes the plan given to you in the prompt through tool calls. "
+            "If the plan concludes that no action should be taken, do not call any tool."
+        )
         llm.system_prompt = system_prompt
         rsp = llm.generate(
             prompt=chaining_message,
             tool_schema=self.agent.tool_manager.get_all_tools_schema(selected_tools),
-            tool_choice="required",
+            tool_choice="auto",
         )
         response_message = rsp.choices[0].message
         cot_plan = Plan(step=step, llm_plan=response_message, ttl=ttl)
@@ -190,12 +193,15 @@ class CoTReasoning(Reasoning):
         # Pass plan content to agent for display
         if hasattr(self.agent, "_step_display_data"):
             self.agent._step_display_data["plan_content"] = chaining_message
-        system_prompt = "You are an executor that executes the plan given to you in the prompt through tool calls."
+        system_prompt = (
+            "You are an executor that executes the plan given to you in the prompt through tool calls. "
+            "If the plan concludes that no action should be taken, do not call any tool."
+        )
         llm.system_prompt = system_prompt
         rsp = await llm.agenerate(
             prompt=chaining_message,
             tool_schema=self.agent.tool_manager.get_all_tools_schema(selected_tools),
-            tool_choice="required",
+            tool_choice="auto",
         )
         response_message = rsp.choices[0].message
         cot_plan = Plan(step=step, llm_plan=response_message, ttl=ttl)

--- a/mesa_llm/reasoning/cot.py
+++ b/mesa_llm/reasoning/cot.py
@@ -121,12 +121,6 @@ class CoTReasoning(Reasoning):
             obs = self.agent.generate_obs()
 
         llm = self.agent.llm
-        obs_str = str(obs)
-
-        # Add current observation to memory (for record)
-        self.agent.memory.add_to_memory(
-            type="Observation", content={"content": obs_str}
-        )
         system_prompt = self.get_cot_system_prompt(obs)
 
         llm.system_prompt = system_prompt
@@ -138,7 +132,7 @@ class CoTReasoning(Reasoning):
 
         chaining_message = rsp.choices[0].message.content
         self.agent.memory.add_to_memory(
-            type="Plan", content={"content": chaining_message}
+            type="plan", content={"content": chaining_message}
         )
 
         # Pass plan content to agent for display
@@ -149,10 +143,6 @@ class CoTReasoning(Reasoning):
             selected_tools=selected_tools,
             ttl=ttl,
             tool_calls=tool_calls,
-        )
-
-        self.agent.memory.add_to_memory(
-            type="Plan-Execution", content={"content": str(cot_plan)}
         )
 
         return cot_plan
@@ -192,11 +182,6 @@ class CoTReasoning(Reasoning):
             obs = await self.agent.agenerate_obs()
 
         llm = self.agent.llm
-
-        obs_str = str(obs)
-        await self.agent.memory.aadd_to_memory(
-            type="Observation", content={"content": obs_str}
-        )
         system_prompt = self.get_cot_system_prompt(obs)
         llm.system_prompt = system_prompt
 
@@ -208,7 +193,7 @@ class CoTReasoning(Reasoning):
 
         chaining_message = rsp.choices[0].message.content
         await self.agent.memory.aadd_to_memory(
-            type="Plan", content={"content": chaining_message}
+            type="plan", content={"content": chaining_message}
         )
 
         # Pass plan content to agent for display
@@ -219,10 +204,6 @@ class CoTReasoning(Reasoning):
             selected_tools=selected_tools,
             ttl=ttl,
             tool_calls=tool_calls,
-        )
-
-        await self.agent.memory.aadd_to_memory(
-            type="Plan-Execution", content={"content": str(cot_plan)}
         )
 
         return cot_plan

--- a/mesa_llm/reasoning/cot.py
+++ b/mesa_llm/reasoning/cot.py
@@ -120,7 +120,6 @@ class CoTReasoning(Reasoning):
         if obs is None:
             obs = self.agent.generate_obs()
 
-        step = obs.step + 1
         llm = self.agent.llm
         obs_str = str(obs)
 
@@ -145,18 +144,12 @@ class CoTReasoning(Reasoning):
         # Pass plan content to agent for display
         if hasattr(self.agent, "_step_display_data"):
             self.agent._step_display_data["plan_content"] = chaining_message
-        system_prompt = (
-            "You are an executor that executes the plan given to you in the prompt through tool calls. "
-            "If the plan concludes that no action should be taken, do not call any tool."
+        cot_plan = self.execute_tool_call(
+            chaining_message,
+            selected_tools=selected_tools,
+            ttl=ttl,
+            tool_calls=tool_calls,
         )
-        llm.system_prompt = system_prompt
-        rsp = llm.generate(
-            prompt=chaining_message,
-            tool_schema=self.agent.tool_manager.get_all_tools_schema(selected_tools),
-            tool_choice=tool_calls,
-        )
-        response_message = rsp.choices[0].message
-        cot_plan = Plan(step=step, llm_plan=response_message, ttl=ttl)
 
         self.agent.memory.add_to_memory(
             type="Plan-Execution", content={"content": str(cot_plan)}
@@ -198,7 +191,6 @@ class CoTReasoning(Reasoning):
         if obs is None:
             obs = await self.agent.agenerate_obs()
 
-        step = obs.step + 1
         llm = self.agent.llm
 
         obs_str = str(obs)
@@ -222,18 +214,12 @@ class CoTReasoning(Reasoning):
         # Pass plan content to agent for display
         if hasattr(self.agent, "_step_display_data"):
             self.agent._step_display_data["plan_content"] = chaining_message
-        system_prompt = (
-            "You are an executor that executes the plan given to you in the prompt through tool calls. "
-            "If the plan concludes that no action should be taken, do not call any tool."
+        cot_plan = await self.aexecute_tool_call(
+            chaining_message,
+            selected_tools=selected_tools,
+            ttl=ttl,
+            tool_calls=tool_calls,
         )
-        llm.system_prompt = system_prompt
-        rsp = await llm.agenerate(
-            prompt=chaining_message,
-            tool_schema=self.agent.tool_manager.get_all_tools_schema(selected_tools),
-            tool_choice=tool_calls,
-        )
-        response_message = rsp.choices[0].message
-        cot_plan = Plan(step=step, llm_plan=response_message, ttl=ttl)
 
         await self.agent.memory.aadd_to_memory(
             type="Plan-Execution", content={"content": str(cot_plan)}

--- a/mesa_llm/reasoning/cot.py
+++ b/mesa_llm/reasoning/cot.py
@@ -14,8 +14,8 @@ class CoTReasoning(Reasoning):
         - **agent** (LLMAgent reference)
 
     Methods:
-        - **plan(obs, ttl=1, prompt=None, selected_tools=None)** → *Plan* - Generate synchronous plan with CoT reasoning
-        - **async aplan(obs, ttl=1, prompt=None, selected_tools=None)** → *Plan* - Generate asynchronous plan with CoT reasoning
+        - **plan(obs, ttl=1, prompt=None, selected_tools=None, tool_calls="auto")** → *Plan* - Generate synchronous plan with CoT reasoning
+        - **async aplan(obs, ttl=1, prompt=None, selected_tools=None, tool_calls="auto")** → *Plan* - Generate asynchronous plan with CoT reasoning
 
     Reasoning Format:
         Thought 1: [Initial reasoning based on observation]
@@ -91,9 +91,24 @@ class CoTReasoning(Reasoning):
         obs: Observation | None = None,
         ttl: int = 1,
         selected_tools: list[str] | None = None,
+        tool_calls: str | None = "auto",
     ) -> Plan:
         """
-        Plan the next (CoT) action based on the current observation and the agent's memory.
+        Plan the next (CoT) action based on the current observation and the
+        agent's memory.
+
+        ``tool_calls`` controls the execution-phase LiteLLM ``tool_choice``.
+        The reasoning pass still keeps tool use disabled with ``"none"``.
+
+        Supported values in Mesa-LLM are:
+        - ``None``: defer to LiteLLM/provider default behavior. In practice,
+          this usually means no tool calls when no tools are provided and
+          behavior similar to ``"auto"`` when tools are available.
+        - ``"none"``: never return tool calls; return a normal assistant
+          message instead.
+        - ``"auto"``: allow the model to either return a normal assistant
+          message or call one or more tools.
+        - ``"required"``: require the model to call one or more tools.
         """
         # If no prompt is provided, use the agent's default step prompt
         if prompt is None:
@@ -138,7 +153,7 @@ class CoTReasoning(Reasoning):
         rsp = llm.generate(
             prompt=chaining_message,
             tool_schema=self.agent.tool_manager.get_all_tools_schema(selected_tools),
-            tool_choice="auto",
+            tool_choice=tool_calls,
         )
         response_message = rsp.choices[0].message
         cot_plan = Plan(step=step, llm_plan=response_message, ttl=ttl)
@@ -155,9 +170,23 @@ class CoTReasoning(Reasoning):
         obs: Observation | None = None,
         ttl: int = 1,
         selected_tools: list[str] | None = None,
+        tool_calls: str | None = "auto",
     ) -> Plan:
         """
         Asynchronous version of plan() method for parallel planning.
+
+        ``tool_calls`` controls the execution-phase LiteLLM ``tool_choice``.
+        The reasoning pass still keeps tool use disabled with ``"none"``.
+
+        Supported values in Mesa-LLM are:
+        - ``None``: defer to LiteLLM/provider default behavior. In practice,
+          this usually means no tool calls when no tools are provided and
+          behavior similar to ``"auto"`` when tools are available.
+        - ``"none"``: never return tool calls; return a normal assistant
+          message instead.
+        - ``"auto"``: allow the model to either return a normal assistant
+          message or call one or more tools.
+        - ``"required"``: require the model to call one or more tools.
         """
         # If no prompt is provided, use the agent's default step prompt
         if prompt is None:
@@ -201,7 +230,7 @@ class CoTReasoning(Reasoning):
         rsp = await llm.agenerate(
             prompt=chaining_message,
             tool_schema=self.agent.tool_manager.get_all_tools_schema(selected_tools),
-            tool_choice="auto",
+            tool_choice=tool_calls,
         )
         response_message = rsp.choices[0].message
         cot_plan = Plan(step=step, llm_plan=response_message, ttl=ttl)

--- a/mesa_llm/reasoning/react.py
+++ b/mesa_llm/reasoning/react.py
@@ -22,8 +22,8 @@ class ReActReasoning(Reasoning):
         - **agent** (LLMAgent reference)
 
     Methods:
-        - **plan(prompt, obs=None, ttl=1, selected_tools=None)** → *Plan* - Generate synchronous plan with ReAct reasoning
-        - **async aplan(prompt, obs=None, ttl=1, selected_tools=None)** → *Plan* - Generate asynchronous plan with ReAct reasoning
+        - **plan(prompt, obs=None, ttl=1, selected_tools=None, tool_calls="auto")** → *Plan* - Generate synchronous plan with ReAct reasoning
+        - **async aplan(prompt, obs=None, ttl=1, selected_tools=None, tool_calls="auto")** → *Plan* - Generate asynchronous plan with ReAct reasoning
     """
 
     def __init__(self, agent: "LLMAgent"):
@@ -62,9 +62,24 @@ class ReActReasoning(Reasoning):
         obs: Observation | None = None,
         ttl: int = 1,
         selected_tools: list[str] | None = None,
+        tool_calls: str | None = "auto",
     ) -> Plan:
         """
-        Plan the next (ReAct) action based on the current observation and the agent's memory.
+        Plan the next (ReAct) action based on the current observation and the
+        agent's memory.
+
+        ``tool_calls`` controls the execution-phase LiteLLM ``tool_choice``.
+        The reasoning pass still keeps tool use disabled with ``"none"``.
+
+        Supported values in Mesa-LLM are:
+        - ``None``: defer to LiteLLM/provider default behavior. In practice,
+          this usually means no tool calls when no tools are provided and
+          behavior similar to ``"auto"`` when tools are available.
+        - ``"none"``: never return tool calls; return a normal assistant
+          message instead.
+        - ``"auto"``: allow the model to either return a normal assistant
+          message or call one or more tools.
+        - ``"required"``: require the model to call one or more tools.
         """
 
         if obs is None:
@@ -103,6 +118,7 @@ class ReActReasoning(Reasoning):
             formatted_response["action"],
             selected_tools=selected_tools,
             ttl=ttl,
+            tool_calls=tool_calls,
         )
 
         return react_plan
@@ -113,9 +129,23 @@ class ReActReasoning(Reasoning):
         obs: Observation | None = None,
         ttl: int = 1,
         selected_tools: list[str] | None = None,
+        tool_calls: str | None = "auto",
     ) -> Plan:
         """
         Asynchronous version of plan() method for parallel planning.
+
+        ``tool_calls`` controls the execution-phase LiteLLM ``tool_choice``.
+        The reasoning pass still keeps tool use disabled with ``"none"``.
+
+        Supported values in Mesa-LLM are:
+        - ``None``: defer to LiteLLM/provider default behavior. In practice,
+          this usually means no tool calls when no tools are provided and
+          behavior similar to ``"auto"`` when tools are available.
+        - ``"none"``: never return tool calls; return a normal assistant
+          message instead.
+        - ``"auto"``: allow the model to either return a normal assistant
+          message or call one or more tools.
+        - ``"required"``: require the model to call one or more tools.
         """
         if obs is None:
             obs = await self.agent.agenerate_obs()
@@ -154,6 +184,7 @@ class ReActReasoning(Reasoning):
             formatted_response["action"],
             selected_tools=selected_tools,
             ttl=ttl,
+            tool_calls=tool_calls,
         )
 
         return react_plan

--- a/mesa_llm/reasoning/reasoning.py
+++ b/mesa_llm/reasoning/reasoning.py
@@ -110,14 +110,17 @@ class Reasoning(ABC):
         selected_tools: list[str] | None = None,
         ttl: int = 1,
     ):
-        system_prompt = "You are an executor that executes the plan given to you in the prompt through tool calls."
+        system_prompt = (
+            "You are an executor that executes the plan given to you in the prompt through tool calls. "
+            "If the plan concludes that no action should be taken, do not call any tool."
+        )
         self.agent.llm.system_prompt = system_prompt
         rsp = self.agent.llm.generate(
             prompt=chaining_message,
             tool_schema=self.agent.tool_manager.get_all_tools_schema(
                 selected_tools=selected_tools
             ),
-            tool_choice="required",
+            tool_choice="auto",
         )
         response_message = rsp.choices[0].message
         plan = Plan(step=self.agent.model.steps, llm_plan=response_message, ttl=ttl)
@@ -133,14 +136,17 @@ class Reasoning(ABC):
         """
         Asynchronous version of execute_tool_call() method.
         """
-        system_prompt = "You are an executor that executes the plan given to you in the prompt through tool calls."
+        system_prompt = (
+            "You are an executor that executes the plan given to you in the prompt through tool calls. "
+            "If the plan concludes that no action should be taken, do not call any tool."
+        )
         self.agent.llm.system_prompt = system_prompt
         rsp = await self.agent.llm.agenerate(
             prompt=chaining_message,
             tool_schema=self.agent.tool_manager.get_all_tools_schema(
                 selected_tools=selected_tools
             ),
-            tool_choice="required",
+            tool_choice="auto",
         )
         response_message = rsp.choices[0].message
         plan = Plan(step=self.agent.model.steps, llm_plan=response_message, ttl=ttl)

--- a/mesa_llm/reasoning/reasoning.py
+++ b/mesa_llm/reasoning/reasoning.py
@@ -61,8 +61,8 @@ class Reasoning(ABC):
         - **agent** (LLMAgent reference)
 
     Methods:
-        - **abstract plan(prompt, obs=None, ttl=1, selected_tools=None)** → *Plan* - Generate synchronous plan
-        - **async aplan(prompt, obs=None, ttl=1, selected_tools=None)** → *Plan* - Generate asynchronous plan
+        - **abstract plan(prompt, obs=None, ttl=1, selected_tools=None, tool_calls="auto")** → *Plan* - Generate synchronous plan
+        - **async aplan(prompt, obs=None, ttl=1, selected_tools=None, tool_calls="auto")** → *Plan* - Generate asynchronous plan
 
 
     Reasoning Flow:
@@ -83,8 +83,35 @@ class Reasoning(ABC):
         obs: Observation | None = None,
         ttl: int = 1,
         selected_tools: list[str] | None = None,
+        tool_calls: str | None = "auto",
     ) -> Plan:
-        pass
+        """Generate a plan for the next action.
+
+        Args:
+            prompt: Optional prompt override for the reasoning strategy.
+            obs: Optional observation to plan against.
+            ttl: Time-to-live for the generated plan.
+            selected_tools: Optional explicit tool allowlist forwarded to
+                ``ToolManager.get_all_tools_schema()``.
+            tool_calls: Execution-phase LiteLLM ``tool_choice`` override used
+                when converting the natural-language plan into tool calls.
+                Planning still keeps tool use disabled.
+
+                Supported values in Mesa-LLM are:
+                - ``None``: defer to LiteLLM/provider default behavior. In
+                  practice, this usually means no tool calls when no tools are
+                  provided and behavior similar to ``"auto"`` when tools are
+                  available.
+                - ``"none"``: never return tool calls; return a normal
+                  assistant message instead.
+                - ``"auto"``: allow the model to either return a normal
+                  assistant message or call one or more tools.
+                - ``"required"``: require the model to call one or more tools.
+
+                Mesa-LLM currently exposes only these string choices, not
+                provider-specific object forms. See LiteLLM docs:
+                https://docs.litellm.ai/
+        """
 
     async def aplan(
         self,
@@ -92,6 +119,7 @@ class Reasoning(ABC):
         obs: Observation | None = None,
         ttl: int = 1,
         selected_tools: list[str] | None = None,
+        tool_calls: str | None = "auto",
     ) -> Plan:
         """
         Asynchronous version of plan() method for parallel planning.
@@ -102,6 +130,7 @@ class Reasoning(ABC):
             obs=obs,
             ttl=ttl,
             selected_tools=selected_tools,
+            tool_calls=tool_calls,
         )
 
     def execute_tool_call(
@@ -109,7 +138,30 @@ class Reasoning(ABC):
         chaining_message,
         selected_tools: list[str] | None = None,
         ttl: int = 1,
+        tool_calls: str | None = "auto",
     ):
+        """Turn a natural-language plan into tool calls.
+
+        Args:
+            chaining_message: Natural-language plan or action text to execute.
+            selected_tools: Optional explicit tool allowlist.
+            ttl: Time-to-live for the returned plan.
+            tool_calls: LiteLLM ``tool_choice`` passed to the execution call.
+                Supported values in Mesa-LLM are:
+                - ``None``: defer to LiteLLM/provider default behavior. In
+                  practice, this usually means no tool calls when no tools are
+                  provided and behavior similar to ``"auto"`` when tools are
+                  available.
+                - ``"none"``: never return tool calls; return a normal
+                  assistant message instead.
+                - ``"auto"``: allow the model to either return a normal
+                  assistant message or call one or more tools.
+                - ``"required"``: require the model to call one or more tools.
+
+                Mesa-LLM currently exposes only these string choices, not
+                provider-specific object forms. See LiteLLM docs:
+                https://docs.litellm.ai/
+        """
         system_prompt = (
             "You are an executor that executes the plan given to you in the prompt through tool calls. "
             "If the plan concludes that no action should be taken, do not call any tool."
@@ -120,7 +172,7 @@ class Reasoning(ABC):
             tool_schema=self.agent.tool_manager.get_all_tools_schema(
                 selected_tools=selected_tools
             ),
-            tool_choice="auto",
+            tool_choice=tool_calls,
         )
         response_message = rsp.choices[0].message
         plan = Plan(step=self.agent.model.steps, llm_plan=response_message, ttl=ttl)
@@ -132,6 +184,7 @@ class Reasoning(ABC):
         chaining_message,
         selected_tools: list[str] | None = None,
         ttl: int = 1,
+        tool_calls: str | None = "auto",
     ):
         """
         Asynchronous version of execute_tool_call() method.
@@ -146,7 +199,7 @@ class Reasoning(ABC):
             tool_schema=self.agent.tool_manager.get_all_tools_schema(
                 selected_tools=selected_tools
             ),
-            tool_choice="auto",
+            tool_choice=tool_calls,
         )
         response_message = rsp.choices[0].message
         plan = Plan(step=self.agent.model.steps, llm_plan=response_message, ttl=ttl)

--- a/mesa_llm/reasoning/reasoning.py
+++ b/mesa_llm/reasoning/reasoning.py
@@ -176,6 +176,9 @@ class Reasoning(ABC):
         )
         response_message = rsp.choices[0].message
         plan = Plan(step=self.agent.model.steps, llm_plan=response_message, ttl=ttl)
+        self.agent.memory.add_to_memory(
+            type="plan_execution", content={"content": str(plan)}
+        )
 
         return plan
 
@@ -203,5 +206,8 @@ class Reasoning(ABC):
         )
         response_message = rsp.choices[0].message
         plan = Plan(step=self.agent.model.steps, llm_plan=response_message, ttl=ttl)
+        await self.agent.memory.aadd_to_memory(
+            type="plan_execution", content={"content": str(plan)}
+        )
 
         return plan

--- a/mesa_llm/reasoning/rewoo.py
+++ b/mesa_llm/reasoning/rewoo.py
@@ -22,8 +22,8 @@ class ReWOOReasoning(Reasoning):
         - **current_obs** (Observation) - Last observation used for planning
 
     Methods:
-        - **plan(prompt, obs=None, ttl=1, selected_tools=None)** → *Plan* - Generate synchronous plan with ReWOO reasoning
-        - **async aplan(prompt, obs=None, ttl=1, selected_tools=None)** → *Plan* - Generate asynchronous plan with ReWOO reasoning
+        - **plan(prompt, obs=None, ttl=1, selected_tools=None, tool_calls="auto")** → *Plan* - Generate synchronous plan with ReWOO reasoning
+        - **async aplan(prompt, obs=None, ttl=1, selected_tools=None, tool_calls="auto")** → *Plan* - Generate asynchronous plan with ReWOO reasoning
     """
 
     def __init__(self, agent: "LLMAgent"):
@@ -105,9 +105,24 @@ class ReWOOReasoning(Reasoning):
         obs: Observation | None = None,
         ttl: int = 1,
         selected_tools: list[str] | None = None,
+        tool_calls: str | None = "auto",
     ) -> Plan:
         """
-        Plan the next (ReWOO) action based on the current observation and the agent's memory.
+        Plan the next (ReWOO) action based on the current observation and the
+        agent's memory.
+
+        ``tool_calls`` controls the execution-phase LiteLLM ``tool_choice``.
+        The planning pass still keeps tool use disabled with ``"none"``.
+
+        Supported values in Mesa-LLM are:
+        - ``None``: defer to LiteLLM/provider default behavior. In practice,
+          this usually means no tool calls when no tools are provided and
+          behavior similar to ``"auto"`` when tools are available.
+        - ``"none"``: never return tool calls; return a normal assistant
+          message instead.
+        - ``"auto"``: allow the model to either return a normal assistant
+          message or call one or more tools.
+        - ``"required"``: require the model to call one or more tools.
         """
         # If we have remaining tool calls, skip observation and plan generation
         if self.remaining_tool_calls > 0:
@@ -149,6 +164,7 @@ class ReWOOReasoning(Reasoning):
             rsp.choices[0].message.content,
             selected_tools=selected_tools,
             ttl=ttl,
+            tool_calls=tool_calls,
         )
         # Count the number of tool calls in the response and set remaining_tool_calls
         self.remaining_tool_calls = len(
@@ -164,9 +180,23 @@ class ReWOOReasoning(Reasoning):
         obs: Observation | None = None,
         ttl: int = 1,
         selected_tools: list[str] | None = None,
+        tool_calls: str | None = "auto",
     ) -> Plan:
         """
         Asynchronous version of plan() method for parallel planning.
+
+        ``tool_calls`` controls the execution-phase LiteLLM ``tool_choice``.
+        The planning pass still keeps tool use disabled with ``"none"``.
+
+        Supported values in Mesa-LLM are:
+        - ``None``: defer to LiteLLM/provider default behavior. In practice,
+          this usually means no tool calls when no tools are provided and
+          behavior similar to ``"auto"`` when tools are available.
+        - ``"none"``: never return tool calls; return a normal assistant
+          message instead.
+        - ``"auto"``: allow the model to either return a normal assistant
+          message or call one or more tools.
+        - ``"required"``: require the model to call one or more tools.
         """
         # If we have remaining tool calls, skip observation and plan generation
         if self.remaining_tool_calls > 0:
@@ -208,6 +238,7 @@ class ReWOOReasoning(Reasoning):
             rsp.choices[0].message.content,
             selected_tools=selected_tools,
             ttl=ttl,
+            tool_calls=tool_calls,
         )
         # Count the number of tool calls in the response and set remaining_tool_calls
         self.remaining_tool_calls = len(

--- a/mesa_llm/reasoning/rewoo.py
+++ b/mesa_llm/reasoning/rewoo.py
@@ -151,10 +151,9 @@ class ReWOOReasoning(Reasoning):
             ttl=ttl,
         )
         # Count the number of tool calls in the response and set remaining_tool_calls
-        if hasattr(rewoo_plan.llm_plan, "tool_calls"):
-            self.remaining_tool_calls = len(rewoo_plan.llm_plan.tool_calls)
-        else:
-            self.remaining_tool_calls = 0
+        self.remaining_tool_calls = len(
+            getattr(rewoo_plan.llm_plan, "tool_calls", None) or []
+        )
         self.current_plan = rewoo_plan.llm_plan
 
         return rewoo_plan
@@ -211,10 +210,9 @@ class ReWOOReasoning(Reasoning):
             ttl=ttl,
         )
         # Count the number of tool calls in the response and set remaining_tool_calls
-        if hasattr(rewoo_plan.llm_plan, "tool_calls"):
-            self.remaining_tool_calls = len(rewoo_plan.llm_plan.tool_calls)
-        else:
-            self.remaining_tool_calls = 0
+        self.remaining_tool_calls = len(
+            getattr(rewoo_plan.llm_plan, "tool_calls", None) or []
+        )
         self.current_plan = rewoo_plan.llm_plan
 
         return rewoo_plan

--- a/tests/test_async_memory.py
+++ b/tests/test_async_memory.py
@@ -25,10 +25,12 @@ class MockModel:
 
 
 class MockReasoning(Reasoning):
-    def plan(self, prompt, obs=None, ttl=1, selected_tools=None):
+    def plan(self, prompt, obs=None, ttl=1, selected_tools=None, tool_calls="auto"):
         return MagicMock()
 
-    async def aplan(self, prompt, obs=None, ttl=1, selected_tools=None):
+    async def aplan(
+        self, prompt, obs=None, ttl=1, selected_tools=None, tool_calls="auto"
+    ):
         return MagicMock()
 
 

--- a/tests/test_integration/test_memory_reasoning.py
+++ b/tests/test_integration/test_memory_reasoning.py
@@ -520,7 +520,7 @@ class TestReWOOWithShortTermMemory:
         assert isinstance(plan, Plan)
         assert memory.step_content["plan"]["content"] == plan_content
         reasoning.execute_tool_call.assert_called_once_with(
-            plan_content, selected_tools=None, ttl=1
+            plan_content, selected_tools=None, ttl=1, tool_calls="auto"
         )
         agent.generate_obs.assert_called_once()
 
@@ -542,7 +542,7 @@ class TestReWOOWithShortTermMemory:
         assert reasoning.current_obs == agent.agenerate_obs.return_value
         assert reasoning.remaining_tool_calls == 0
         reasoning.aexecute_tool_call.assert_awaited_once_with(
-            plan_content, selected_tools=None, ttl=1
+            plan_content, selected_tools=None, ttl=1, tool_calls="auto"
         )
         agent.agenerate_obs.assert_awaited_once()
 
@@ -602,7 +602,7 @@ class TestReWOOWithSTLTMemory:
         assert isinstance(plan, Plan)
         assert memory.step_content["plan"]["content"] == plan_content
         reasoning.execute_tool_call.assert_called_once_with(
-            plan_content, selected_tools=None, ttl=1
+            plan_content, selected_tools=None, ttl=1, tool_calls="auto"
         )
         agent.generate_obs.assert_called_once()
 
@@ -623,7 +623,7 @@ class TestReWOOWithSTLTMemory:
         assert isinstance(plan, Plan)
         assert memory.step_content["plan"]["content"] == plan_content
         reasoning.aexecute_tool_call.assert_awaited_once_with(
-            plan_content, selected_tools=None, ttl=1
+            plan_content, selected_tools=None, ttl=1, tool_calls="auto"
         )
         agent.agenerate_obs.assert_awaited_once()
 
@@ -687,7 +687,7 @@ class TestReWOOWithEpisodicMemory:
         assert entries[0].content["plan"]["importance"] == 3
         assert memory.grade_event_importance.call_count == 1
         reasoning.execute_tool_call.assert_called_once_with(
-            plan_content, selected_tools=None, ttl=1
+            plan_content, selected_tools=None, ttl=1, tool_calls="auto"
         )
 
     def test_async_plan_works(self, monkeypatch):
@@ -711,6 +711,6 @@ class TestReWOOWithEpisodicMemory:
         assert entries[0].content["plan"]["importance"] == 3
         assert memory.grade_event_importance.call_count == 1
         reasoning.aexecute_tool_call.assert_awaited_once_with(
-            plan_content, selected_tools=None, ttl=1
+            plan_content, selected_tools=None, ttl=1, tool_calls="auto"
         )
         agent.agenerate_obs.assert_awaited_once()

--- a/tests/test_integration/test_memory_reasoning.py
+++ b/tests/test_integration/test_memory_reasoning.py
@@ -113,7 +113,7 @@ class TestCoTWithShortTermMemory:
         assert "Short-Term Memory" in prompt or "Short" in prompt
 
     def test_plan_records_to_memory(self):
-        """CoT plan() adds Observation, Plan, and Plan-Execution to memory."""
+        """CoT plan() adds plan and plan_execution to memory."""
         agent, memory, reasoning = self._setup()
 
         plan_content = "Thought 1: reasoning\nAction: move north"
@@ -127,11 +127,11 @@ class TestCoTWithShortTermMemory:
         assert isinstance(plan, Plan)
         assert plan.step == 1
         assert plan.llm_plan is rsp_exec.choices[0].message
-        assert memory.step_content["Observation"]["content"] == str(obs)
-        assert memory.step_content["Plan"]["content"] == plan_content
-        assert memory.step_content["Plan-Execution"]["content"] == str(plan)
+        assert memory.step_content["plan"]["content"] == plan_content
+        assert memory.step_content["plan_execution"]["content"] == str(plan)
         assert agent._step_display_data["plan_content"] == plan_content
         assert agent.llm.generate.call_count == 2
+        assert "observation" not in memory.step_content
 
     def test_async_plan_works(self):
         """aplan() completes without error using ShortTermMemory."""
@@ -149,11 +149,11 @@ class TestCoTWithShortTermMemory:
         assert isinstance(plan, Plan)
         assert plan.step == 1
         assert plan.llm_plan is rsp_exec.choices[0].message
-        assert memory.step_content["Observation"]["content"] == str(obs)
-        assert memory.step_content["Plan"]["content"] == plan_content
-        assert memory.step_content["Plan-Execution"]["content"] == str(plan)
+        assert memory.step_content["plan"]["content"] == plan_content
+        assert memory.step_content["plan_execution"]["content"] == str(plan)
         assert agent._step_display_data["plan_content"] == plan_content
         assert agent.llm.agenerate.await_count == 2
+        assert "observation" not in memory.step_content
 
 
 class TestCoTWithSTLTMemory:
@@ -205,10 +205,10 @@ class TestCoTWithSTLTMemory:
 
         assert isinstance(plan, Plan)
         assert plan.step == 1
-        assert memory.step_content["Observation"]["content"] == str(obs)
-        assert memory.step_content["Plan"]["content"] == plan_content
-        assert memory.step_content["Plan-Execution"]["content"] == str(plan)
+        assert memory.step_content["plan"]["content"] == plan_content
+        assert memory.step_content["plan_execution"]["content"] == str(plan)
         assert agent.llm.generate.call_count == 2
+        assert "observation" not in memory.step_content
 
     def test_async_plan_works(self, monkeypatch):
         """aplan() completes with STLTMemory."""
@@ -225,10 +225,10 @@ class TestCoTWithSTLTMemory:
 
         assert isinstance(plan, Plan)
         assert plan.step == 1
-        assert memory.step_content["Observation"]["content"] == str(obs)
-        assert memory.step_content["Plan"]["content"] == plan_content
-        assert memory.step_content["Plan-Execution"]["content"] == str(plan)
+        assert memory.step_content["plan"]["content"] == plan_content
+        assert memory.step_content["plan_execution"]["content"] == str(plan)
         assert agent.llm.agenerate.await_count == 2
+        assert "observation" not in memory.step_content
 
 
 class TestCoTWithEpisodicMemory:
@@ -281,14 +281,12 @@ class TestCoTWithEpisodicMemory:
 
         assert isinstance(plan, Plan)
         entries = list(memory.memory_entries)
-        assert len(entries) == 3
-        assert entries[0].content["Observation"]["content"] == str(obs)
-        assert entries[1].content["Plan"]["content"] == plan_content
-        assert entries[2].content["Plan-Execution"]["content"] == str(plan)
-        assert entries[0].content["Observation"]["importance"] == 3
-        assert entries[1].content["Plan"]["importance"] == 3
-        assert entries[2].content["Plan-Execution"]["importance"] == 3
-        assert memory.grade_event_importance.call_count == 3
+        assert len(entries) == 2
+        assert entries[0].content["plan"]["content"] == plan_content
+        assert entries[1].content["plan_execution"]["content"] == str(plan)
+        assert entries[0].content["plan"]["importance"] == 3
+        assert entries[1].content["plan_execution"]["importance"] == 3
+        assert memory.grade_event_importance.call_count == 2
 
     def test_async_plan_works(self, monkeypatch):
         """aplan() completes with EpisodicMemory."""
@@ -304,14 +302,12 @@ class TestCoTWithEpisodicMemory:
 
         assert isinstance(plan, Plan)
         entries = list(memory.memory_entries)
-        assert len(entries) == 3
-        assert entries[0].content["Observation"]["content"] == str(obs)
-        assert entries[1].content["Plan"]["content"] == plan_content
-        assert entries[2].content["Plan-Execution"]["content"] == str(plan)
-        assert entries[0].content["Observation"]["importance"] == 3
-        assert entries[1].content["Plan"]["importance"] == 3
-        assert entries[2].content["Plan-Execution"]["importance"] == 3
-        assert memory.agrade_event_importance.await_count == 3
+        assert len(entries) == 2
+        assert entries[0].content["plan"]["content"] == plan_content
+        assert entries[1].content["plan_execution"]["content"] == str(plan)
+        assert entries[0].content["plan"]["importance"] == 3
+        assert entries[1].content["plan_execution"]["importance"] == 3
+        assert memory.agrade_event_importance.await_count == 2
 
 
 # ===================================================================
@@ -369,12 +365,8 @@ class TestReActWithSTLTMemory:
         agent, memory, reasoning = self._setup(monkeypatch)
 
         rsp_react = make_react_response()
-        agent.llm.generate = Mock(return_value=rsp_react)
-
         rsp_exec = make_llm_response("executing")
-        reasoning.execute_tool_call = Mock(
-            return_value=Plan(step=1, llm_plan=rsp_exec.choices[0].message)
-        )
+        agent.llm.generate = Mock(side_effect=[rsp_react, rsp_exec])
 
         obs = Observation(step=0, self_state={}, local_state={})
         plan = reasoning.plan(obs=obs)
@@ -382,21 +374,17 @@ class TestReActWithSTLTMemory:
         assert isinstance(plan, Plan)
         assert memory.step_content["plan"]["reasoning"] == "test reasoning"
         assert memory.step_content["plan"]["action"] == "test action"
-        assert reasoning.execute_tool_call.call_args.args[0] == "test action"
-        assert agent.llm.generate.call_count == 1
+        assert memory.step_content["plan_execution"]["content"] == str(plan)
+        assert agent.llm.generate.call_count == 2
 
     def test_async_plan_works(self, monkeypatch):
         """aplan() completes with STLTMemory."""
         agent, memory, reasoning = self._setup(monkeypatch)
 
         rsp_react = make_react_response()
-        agent.llm.agenerate = AsyncMock(return_value=rsp_react)
-        agent.memory.aadd_to_memory = AsyncMock(side_effect=memory.add_to_memory)
-
         rsp_exec = make_llm_response("executing")
-        reasoning.aexecute_tool_call = AsyncMock(
-            return_value=Plan(step=1, llm_plan=rsp_exec.choices[0].message)
-        )
+        agent.llm.agenerate = AsyncMock(side_effect=[rsp_react, rsp_exec])
+        agent.memory.aadd_to_memory = AsyncMock(side_effect=memory.add_to_memory)
 
         obs = Observation(step=0, self_state={}, local_state={})
         plan = asyncio.run(reasoning.aplan(obs=obs))
@@ -404,8 +392,8 @@ class TestReActWithSTLTMemory:
         assert isinstance(plan, Plan)
         assert memory.step_content["plan"]["reasoning"] == "test reasoning"
         assert memory.step_content["plan"]["action"] == "test action"
-        assert reasoning.aexecute_tool_call.await_args.args[0] == "test action"
-        assert agent.llm.agenerate.await_count == 1
+        assert memory.step_content["plan_execution"]["content"] == str(plan)
+        assert agent.llm.agenerate.await_count == 2
 
 
 class TestReActWithShortTermMemory:
@@ -510,40 +498,31 @@ class TestReWOOWithShortTermMemory:
         plan_content = "multi-step plan content"
         rsp_plan = make_llm_response(plan_content)
         rsp_exec = make_llm_response("executing step 1", tool_calls=[])
-        agent.llm.generate = Mock(return_value=rsp_plan)
-
-        reasoning.execute_tool_call = Mock(
-            return_value=Plan(step=1, llm_plan=rsp_exec.choices[0].message)
-        )
+        agent.llm.generate = Mock(side_effect=[rsp_plan, rsp_exec])
 
         plan = reasoning.plan()
         assert isinstance(plan, Plan)
         assert memory.step_content["plan"]["content"] == plan_content
-        reasoning.execute_tool_call.assert_called_once_with(
-            plan_content, selected_tools=None, ttl=1, tool_calls="auto"
-        )
+        assert memory.step_content["plan_execution"]["content"] == str(plan)
+        assert agent.llm.generate.call_count == 2
         agent.generate_obs.assert_called_once()
 
     def test_async_plan_works(self):
         """aplan() completes with ShortTermMemory."""
-        agent, _memory, reasoning = self._setup()
+        agent, memory, reasoning = self._setup()
 
         plan_content = "async plan content"
         rsp_plan = make_llm_response(plan_content)
         rsp_exec = make_llm_response("executing", tool_calls=[])
-        agent.llm.agenerate = AsyncMock(return_value=rsp_plan)
-
-        reasoning.aexecute_tool_call = AsyncMock(
-            return_value=Plan(step=1, llm_plan=rsp_exec.choices[0].message)
-        )
+        agent.llm.agenerate = AsyncMock(side_effect=[rsp_plan, rsp_exec])
 
         plan = asyncio.run(reasoning.aplan())
         assert isinstance(plan, Plan)
         assert reasoning.current_obs == agent.agenerate_obs.return_value
         assert reasoning.remaining_tool_calls == 0
-        reasoning.aexecute_tool_call.assert_awaited_once_with(
-            plan_content, selected_tools=None, ttl=1, tool_calls="auto"
-        )
+        assert memory.step_content["plan"]["content"] == plan_content
+        assert memory.step_content["plan_execution"]["content"] == str(plan)
+        assert agent.llm.agenerate.await_count == 2
         agent.agenerate_obs.assert_awaited_once()
 
 
@@ -592,18 +571,13 @@ class TestReWOOWithSTLTMemory:
         plan_content = "rewoo plan"
         rsp_plan = make_llm_response(plan_content)
         rsp_exec = make_llm_response("exec", tool_calls=[])
-        agent.llm.generate = Mock(return_value=rsp_plan)
-
-        reasoning.execute_tool_call = Mock(
-            return_value=Plan(step=1, llm_plan=rsp_exec.choices[0].message)
-        )
+        agent.llm.generate = Mock(side_effect=[rsp_plan, rsp_exec])
 
         plan = reasoning.plan()
         assert isinstance(plan, Plan)
         assert memory.step_content["plan"]["content"] == plan_content
-        reasoning.execute_tool_call.assert_called_once_with(
-            plan_content, selected_tools=None, ttl=1, tool_calls="auto"
-        )
+        assert memory.step_content["plan_execution"]["content"] == str(plan)
+        assert agent.llm.generate.call_count == 2
         agent.generate_obs.assert_called_once()
 
     def test_async_plan_works(self, monkeypatch):
@@ -613,18 +587,13 @@ class TestReWOOWithSTLTMemory:
         plan_content = "async rewoo plan"
         rsp_plan = make_llm_response(plan_content)
         rsp_exec = make_llm_response("exec", tool_calls=[])
-        agent.llm.agenerate = AsyncMock(return_value=rsp_plan)
-
-        reasoning.aexecute_tool_call = AsyncMock(
-            return_value=Plan(step=1, llm_plan=rsp_exec.choices[0].message)
-        )
+        agent.llm.agenerate = AsyncMock(side_effect=[rsp_plan, rsp_exec])
 
         plan = asyncio.run(reasoning.aplan())
         assert isinstance(plan, Plan)
         assert memory.step_content["plan"]["content"] == plan_content
-        reasoning.aexecute_tool_call.assert_awaited_once_with(
-            plan_content, selected_tools=None, ttl=1, tool_calls="auto"
-        )
+        assert memory.step_content["plan_execution"]["content"] == str(plan)
+        assert agent.llm.agenerate.await_count == 2
         agent.agenerate_obs.assert_awaited_once()
 
 
@@ -673,22 +642,17 @@ class TestReWOOWithEpisodicMemory:
         plan_content = "episodic rewoo plan"
         rsp_plan = make_llm_response(plan_content)
         rsp_exec = make_llm_response("exec", tool_calls=[])
-        agent.llm.generate = Mock(return_value=rsp_plan)
-
-        reasoning.execute_tool_call = Mock(
-            return_value=Plan(step=1, llm_plan=rsp_exec.choices[0].message)
-        )
+        agent.llm.generate = Mock(side_effect=[rsp_plan, rsp_exec])
 
         plan = reasoning.plan()
         assert isinstance(plan, Plan)
         entries = list(memory.memory_entries)
-        assert len(entries) == 1
+        assert len(entries) == 2
         assert entries[0].content["plan"]["content"] == plan_content
+        assert entries[1].content["plan_execution"]["content"] == str(plan)
         assert entries[0].content["plan"]["importance"] == 3
-        assert memory.grade_event_importance.call_count == 1
-        reasoning.execute_tool_call.assert_called_once_with(
-            plan_content, selected_tools=None, ttl=1, tool_calls="auto"
-        )
+        assert entries[1].content["plan_execution"]["importance"] == 3
+        assert memory.grade_event_importance.call_count == 2
 
     def test_async_plan_works(self, monkeypatch):
         """aplan() completes with EpisodicMemory."""
@@ -697,20 +661,17 @@ class TestReWOOWithEpisodicMemory:
         plan_content = "async episodic plan"
         rsp_plan = make_llm_response(plan_content)
         rsp_exec = make_llm_response("exec", tool_calls=[])
-        agent.llm.agenerate = AsyncMock(return_value=rsp_plan)
-
-        reasoning.aexecute_tool_call = AsyncMock(
-            return_value=Plan(step=1, llm_plan=rsp_exec.choices[0].message)
-        )
+        agent.llm.agenerate = AsyncMock(side_effect=[rsp_plan, rsp_exec])
 
         plan = asyncio.run(reasoning.aplan())
         assert isinstance(plan, Plan)
         entries = list(memory.memory_entries)
-        assert len(entries) == 1
+        assert len(entries) == 2
         assert entries[0].content["plan"]["content"] == plan_content
+        assert entries[1].content["plan_execution"]["content"] == str(plan)
         assert entries[0].content["plan"]["importance"] == 3
+        assert entries[1].content["plan_execution"]["importance"] == 3
         assert memory.grade_event_importance.call_count == 1
-        reasoning.aexecute_tool_call.assert_awaited_once_with(
-            plan_content, selected_tools=None, ttl=1, tool_calls="auto"
-        )
+        assert memory.agrade_event_importance.await_count == 1
+        assert agent.llm.agenerate.await_count == 2
         agent.agenerate_obs.assert_awaited_once()

--- a/tests/test_reasoning/test_cot.py
+++ b/tests/test_reasoning/test_cot.py
@@ -118,6 +118,32 @@ class TestCoTReasoning:
         assert result.ttl == 3
         # Check that tool schema was called with selected tools
         assert mock_agent.tool_manager.get_all_tools_schema.call_count == 2
+        assert mock_agent.llm.generate.call_args_list[1].kwargs["tool_choice"] == "auto"
+
+    def test_plan_with_custom_tool_calls(self, llm_response_factory, mock_agent):
+        """Test plan method forwards a custom execution tool choice."""
+        mock_agent.step_prompt = "You are an agent in a simulation"
+        mock_agent.memory = Mock()
+        mock_agent.memory.format_long_term.return_value = "Long term memory"
+        mock_agent.memory.format_short_term.return_value = "Short term memory"
+        mock_agent.memory.add_to_memory = Mock()
+        mock_agent.llm = Mock()
+        mock_agent.tool_manager = Mock()
+        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent._step_display_data = {}
+        mock_plan_response = llm_response_factory(
+            content="Thought 1: Test reasoning\nAction: test_action"
+        )
+        mock_exec_response = llm_response_factory(content="executor response")
+        mock_agent.llm.generate.side_effect = [mock_plan_response, mock_exec_response]
+
+        reasoning = CoTReasoning(mock_agent)
+        obs = Observation(step=1, self_state={}, local_state={})
+        reasoning.plan(obs=obs, tool_calls="required")
+
+        assert mock_agent.llm.generate.call_args_list[1].kwargs["tool_choice"] == (
+            "required"
+        )
 
     def test_plan_no_prompt_error(self, mock_agent):
         """Test plan method raises error when no prompt is provided."""
@@ -191,3 +217,6 @@ class TestCoTReasoning:
         assert result.step == 2
         assert result.ttl == 4
         assert mock_agent.llm.agenerate.call_count == 2
+        assert mock_agent.llm.agenerate.call_args_list[1].kwargs["tool_choice"] == (
+            "auto"
+        )

--- a/tests/test_reasoning/test_cot.py
+++ b/tests/test_reasoning/test_cot.py
@@ -74,14 +74,14 @@ class TestCoTReasoning:
         # Patch llm.generate
         monkeypatch.setattr(agent.llm, "generate", fake_generate)
 
-        # Create an observation (step 0 -> plan.step should be 1)
+        # Create an observation. Plan.step reflects the current model step.
         obs = Observation(step=0, self_state={}, local_state={})
 
         plan = agent.reasoning.plan(obs=obs)
 
         # Assertions
         assert isinstance(plan, Plan)
-        assert plan.step == 1
+        assert plan.step == 0
         assert plan.llm_plan.content == "mock execution"
         assert plan.ttl == 1
         # and our memory.add_to_memory should at least have been called once with type="observation"
@@ -214,7 +214,7 @@ class TestCoTReasoning:
         result = asyncio.run(reasoning.aplan(prompt="Async prompt", obs=obs, ttl=4))
 
         assert isinstance(result, Plan)
-        assert result.step == 2
+        assert result.step == 1
         assert result.ttl == 4
         assert mock_agent.llm.agenerate.call_count == 2
         assert mock_agent.llm.agenerate.call_args_list[1].kwargs["tool_choice"] == (

--- a/tests/test_reasoning/test_cot.py
+++ b/tests/test_reasoning/test_cot.py
@@ -84,11 +84,39 @@ class TestCoTReasoning:
         assert plan.step == 0
         assert plan.llm_plan.content == "mock execution"
         assert plan.ttl == 1
-        # and our memory.add_to_memory should at least have been called once with type="observation"
-        mock_memory.add_to_memory.assert_any_call(
-            type="Observation",
-            content={"content": str(obs)},
+        assert not any(
+            call.kwargs.get("type") == "observation"
+            for call in mock_memory.add_to_memory.call_args_list
         )
+
+    def test_plan_does_not_write_observation_entries(
+        self, llm_response_factory, mock_agent
+    ):
+        """CoT should not persist observations during planning."""
+        mock_agent.step_prompt = "Default step prompt"
+        mock_agent.generate_obs.return_value = Observation(
+            step=1, self_state={}, local_state={}
+        )
+        mock_agent.memory = Mock()
+        mock_agent.memory.format_long_term.return_value = "Long term memory"
+        mock_agent.memory.format_short_term.return_value = "Short term memory"
+        mock_agent.memory.add_to_memory = Mock()
+        mock_agent.llm = Mock()
+        mock_agent.tool_manager = Mock()
+        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent._step_display_data = {}
+
+        mock_plan_response = llm_response_factory(
+            content="Thought 1: reasoning\nAction: act"
+        )
+        mock_exec_response = llm_response_factory(content="executor response")
+        mock_agent.llm.generate.side_effect = [mock_plan_response, mock_exec_response]
+
+        reasoning = CoTReasoning(mock_agent)
+        reasoning.plan(obs=Observation(step=1, self_state={}, local_state={}))
+
+        calls = mock_agent.memory.add_to_memory.call_args_list
+        assert not any(call.kwargs.get("type") == "observation" for call in calls)
 
     def test_plan_with_selected_tools(self, llm_response_factory, mock_agent):
         """Test plan method with selected tools."""

--- a/tests/test_reasoning/test_react.py
+++ b/tests/test_reasoning/test_react.py
@@ -98,6 +98,7 @@ class TestReActReasoning:
             "custom_action",
             selected_tools=None,
             ttl=1,
+            tool_calls="auto",
         )
 
     def test_plan_with_selected_tools(self, llm_response_factory, mock_agent):
@@ -130,6 +131,37 @@ class TestReActReasoning:
             "test_action",
             selected_tools=selected_tools,
             ttl=3,
+            tool_calls="auto",
+        )
+
+    def test_plan_with_custom_tool_calls(self, llm_response_factory, mock_agent):
+        """Test plan method forwards a custom execution tool choice."""
+        mock_agent.step_prompt = "Default step prompt"
+        mock_agent.memory = Mock()
+        mock_agent.memory.get_prompt_ready.return_value = "memory1"
+        mock_agent.memory.get_communication_history.return_value = ""
+        mock_agent.memory.add_to_memory = Mock()
+        mock_agent.llm = Mock()
+        mock_agent.tool_manager = Mock()
+        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+
+        mock_agent.llm.generate.return_value = llm_response_factory(
+            content=json.dumps({"reasoning": "Test reasoning", "action": "test_action"})
+        )
+
+        mock_plan = Plan(step=1, llm_plan=Mock())
+        reasoning = ReActReasoning(mock_agent)
+        reasoning.execute_tool_call = Mock(return_value=mock_plan)
+
+        obs = Observation(step=1, self_state={}, local_state={})
+        result = reasoning.plan(obs=obs, tool_calls="required")
+
+        assert result == mock_plan
+        reasoning.execute_tool_call.assert_called_once_with(
+            "test_action",
+            selected_tools=None,
+            ttl=1,
+            tool_calls="required",
         )
 
     def test_plan_no_prompt_error(self, mock_agent):
@@ -183,6 +215,7 @@ class TestReActReasoning:
             "async_action",
             selected_tools=None,
             ttl=4,
+            tool_calls="auto",
         )
 
     def test_aplan_no_prompt_error(self, mock_agent):

--- a/tests/test_reasoning/test_reasoning.py
+++ b/tests/test_reasoning/test_reasoning.py
@@ -58,7 +58,14 @@ class TestReasoningBase:
 
         # 2. Instantiate a concrete implementation of Reasoning to test the base method
         class ConcreteReasoning(Reasoning):
-            def plan(self, prompt=None, obs=None, ttl=1, selected_tools=None):
+            def plan(
+                self,
+                prompt=None,
+                obs=None,
+                ttl=1,
+                selected_tools=None,
+                tool_calls="auto",
+            ):
                 pass  # Not needed for this test
 
         reasoning = ConcreteReasoning(agent=mock_agent)
@@ -97,7 +104,14 @@ class TestReasoningBase:
         mock_agent.tool_manager.get_all_tools_schema.return_value = []
 
         class ConcreteReasoning(Reasoning):
-            def plan(self, prompt=None, obs=None, ttl=1, selected_tools=None):
+            def plan(
+                self,
+                prompt=None,
+                obs=None,
+                ttl=1,
+                selected_tools=None,
+                tool_calls="auto",
+            ):
                 pass
 
         reasoning = ConcreteReasoning(agent=mock_agent)
@@ -105,3 +119,38 @@ class TestReasoningBase:
 
         assert isinstance(result_plan, Plan)
         assert result_plan.ttl == 7
+
+    def test_execute_tool_call_respects_tool_calls_override(
+        self, llm_response_factory, mock_agent
+    ):
+        """Test that execute_tool_call forwards the caller's tool choice."""
+        mock_agent.model.steps = 5
+        mock_llm_response = llm_response_factory(content="Final LLM message")
+        mock_agent.llm.generate.return_value = mock_llm_response
+        mock_agent.tool_manager.get_all_tools_schema.return_value = [
+            {"schema": "example"}
+        ]
+
+        class ConcreteReasoning(Reasoning):
+            def plan(
+                self,
+                prompt=None,
+                obs=None,
+                ttl=1,
+                selected_tools=None,
+                tool_calls="auto",
+            ):
+                pass
+
+        reasoning = ConcreteReasoning(agent=mock_agent)
+        reasoning.execute_tool_call(
+            "Execute the plan.",
+            selected_tools=["tool1"],
+            tool_calls="required",
+        )
+
+        mock_agent.llm.generate.assert_called_once_with(
+            prompt="Execute the plan.",
+            tool_schema=[{"schema": "example"}],
+            tool_choice="required",
+        )

--- a/tests/test_reasoning/test_reasoning.py
+++ b/tests/test_reasoning/test_reasoning.py
@@ -1,4 +1,5 @@
-from unittest.mock import Mock
+import asyncio
+from unittest.mock import AsyncMock, Mock
 
 from mesa_llm.reasoning.reasoning import (
     Observation,
@@ -92,6 +93,10 @@ class TestReasoningBase:
         assert result_plan.step == 5
         assert result_plan.llm_plan.content == "Final LLM message"
         assert result_plan.ttl == 1
+        mock_agent.memory.add_to_memory.assert_called_once_with(
+            type="plan_execution",
+            content={"content": str(result_plan)},
+        )
 
     def test_execute_tool_call_propagates_ttl(self):
         """Test that execute_tool_call propagates caller-provided TTL."""
@@ -153,4 +158,42 @@ class TestReasoningBase:
             prompt="Execute the plan.",
             tool_schema=[{"schema": "example"}],
             tool_choice="required",
+        )
+
+    def test_aexecute_tool_call_records_plan_execution(
+        self, llm_response_factory, mock_agent
+    ):
+        """Test that aexecute_tool_call logs plan_execution to memory."""
+        mock_agent.model.steps = 5
+        mock_llm_response = llm_response_factory(content="Async final LLM message")
+        mock_agent.llm.agenerate = AsyncMock(return_value=mock_llm_response)
+        mock_agent.tool_manager.get_all_tools_schema.return_value = [
+            {"schema": "example"}
+        ]
+        mock_agent.memory.aadd_to_memory = AsyncMock()
+
+        class ConcreteReasoning(Reasoning):
+            def plan(
+                self,
+                prompt=None,
+                obs=None,
+                ttl=1,
+                selected_tools=None,
+                tool_calls="auto",
+            ):
+                pass
+
+        reasoning = ConcreteReasoning(agent=mock_agent)
+        result_plan = asyncio.run(
+            reasoning.aexecute_tool_call("Execute the plan.", selected_tools=["tool1"])
+        )
+
+        mock_agent.llm.agenerate.assert_awaited_once_with(
+            prompt="Execute the plan.",
+            tool_schema=[{"schema": "example"}],
+            tool_choice="auto",
+        )
+        mock_agent.memory.aadd_to_memory.assert_awaited_once_with(
+            type="plan_execution",
+            content={"content": str(result_plan)},
         )

--- a/tests/test_reasoning/test_reasoning.py
+++ b/tests/test_reasoning/test_reasoning.py
@@ -74,7 +74,7 @@ class TestReasoningBase:
         mock_agent.llm.generate.assert_called_once_with(
             prompt=chaining_message,
             tool_schema=[{"schema": "example"}],
-            tool_choice="required",
+            tool_choice="auto",
         )
         # Assert that the tool manager was asked for the correct schema
         mock_agent.tool_manager.get_all_tools_schema.assert_called_once_with(

--- a/tests/test_reasoning/test_rewoo.py
+++ b/tests/test_reasoning/test_rewoo.py
@@ -120,6 +120,7 @@ class TestReWOOReasoning:
             "Test plan content",
             selected_tools=None,
             ttl=4,
+            tool_calls="auto",
         )
         mock_agent.generate_obs.assert_called_once()
 
@@ -153,6 +154,41 @@ class TestReWOOReasoning:
 
         assert isinstance(result, Plan)
         assert reasoning.remaining_tool_calls == 1
+
+    def test_plan_with_custom_tool_calls(self, llm_response_factory, mock_agent):
+        """Test plan method forwards a custom execution tool choice."""
+        mock_agent.step_prompt = "Default step prompt"
+        mock_agent.generate_obs.return_value = Observation(
+            step=1, self_state={}, local_state={}
+        )
+        mock_agent.memory = Mock()
+        mock_agent.memory.format_long_term.return_value = "Long term memory"
+        mock_agent.memory.format_short_term.return_value = "Short term memory"
+        mock_agent.memory.add_to_memory = Mock()
+        mock_agent.llm = Mock()
+        mock_agent.tool_manager = Mock()
+        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+
+        mock_plan_response = llm_response_factory(content="Test plan content")
+        mock_exec_response = llm_response_factory(
+            content="Execution plan",
+            tool_calls=[_tool_call("call_1")],
+        )
+        mock_agent.llm.generate.side_effect = [mock_plan_response, mock_exec_response]
+
+        reasoning = ReWOOReasoning(mock_agent)
+        reasoning.execute_tool_call = Mock(
+            return_value=Plan(step=1, llm_plan=mock_exec_response.choices[0].message)
+        )
+
+        reasoning.plan(tool_calls="required")
+
+        reasoning.execute_tool_call.assert_called_once_with(
+            "Test plan content",
+            selected_tools=None,
+            ttl=1,
+            tool_calls="required",
+        )
 
     def test_plan_with_selected_tools(self, llm_response_factory, mock_agent):
         """Test plan method with selected tools."""
@@ -334,6 +370,7 @@ class TestReWOOReasoning:
             "Async plan content",
             selected_tools=None,
             ttl=7,
+            tool_calls="auto",
         )
         mock_agent.agenerate_obs.assert_awaited_once()
 

--- a/tests/test_reasoning/test_rewoo.py
+++ b/tests/test_reasoning/test_rewoo.py
@@ -52,6 +52,7 @@ class TestReWOOReasoning:
     def test_plan_with_remaining_tool_calls(self, mock_agent):
         """Test plan method when there are remaining tool calls."""
         mock_agent.generate_obs = Mock()
+        mock_agent.memory = Mock()
         mock_agent.step_prompt = None
 
         reasoning = ReWOOReasoning(mock_agent)
@@ -76,6 +77,7 @@ class TestReWOOReasoning:
         assert result.llm_plan.tool_calls == [mock_tool_2]  # Should get index 1 (3-2)
         assert reasoning.remaining_tool_calls == 1
         mock_agent.generate_obs.assert_not_called()
+        mock_agent.memory.add_to_memory.assert_not_called()
 
     def test_plan_new_plan_generation(self, llm_response_factory, mock_agent):
         """Test plan method when generating a new plan."""
@@ -301,6 +303,8 @@ class TestReWOOReasoning:
     def test_aplan_with_remaining_tool_calls(self, mock_agent):
         """Test aplan method when there are remaining tool calls."""
         mock_agent.generate_obs = Mock()
+        mock_agent.memory = Mock()
+        mock_agent.memory.aadd_to_memory = AsyncMock()
         mock_agent.step_prompt = None
 
         reasoning = ReWOOReasoning(mock_agent)
@@ -320,6 +324,7 @@ class TestReWOOReasoning:
         assert result.llm_plan.tool_calls == [mock_tool_2]  # Should get index 1 (2-1)
         assert reasoning.remaining_tool_calls == 0
         mock_agent.generate_obs.assert_not_called()
+        mock_agent.memory.aadd_to_memory.assert_not_awaited()
 
     def test_aplan_new_plan_generation(self, llm_response_factory, mock_agent):
         """Test aplan uses agenerate_obs (async) not generate_obs (sync)."""

--- a/tests/test_reasoning/test_rewoo.py
+++ b/tests/test_reasoning/test_rewoo.py
@@ -233,6 +233,35 @@ class TestReWOOReasoning:
         assert isinstance(result, Plan)
         assert reasoning.remaining_tool_calls == 0
 
+    def test_plan_with_tool_calls_set_to_none(self, llm_response_factory, mock_agent):
+        """Test plan method when execution returns ``tool_calls=None``."""
+        mock_agent.step_prompt = "Default step prompt"
+        mock_agent.generate_obs.return_value = Observation(
+            step=1, self_state={}, local_state={}
+        )
+        mock_agent.memory = Mock()
+        mock_agent.memory.format_long_term.return_value = "Long term memory"
+        mock_agent.memory.format_short_term.return_value = "Short term memory"
+        mock_agent.memory.add_to_memory = Mock()
+        mock_agent.llm = Mock()
+        mock_agent.tool_manager = Mock()
+        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+
+        mock_plan_response = llm_response_factory(content="Test plan content")
+        mock_agent.llm.generate.return_value = mock_plan_response
+
+        mock_plan_with_none_tool_calls = Mock()
+        mock_plan_with_none_tool_calls.tool_calls = None
+        reasoning = ReWOOReasoning(mock_agent)
+        reasoning.execute_tool_call = Mock(
+            return_value=Plan(step=1, llm_plan=mock_plan_with_none_tool_calls)
+        )
+
+        result = reasoning.plan()
+
+        assert isinstance(result, Plan)
+        assert reasoning.remaining_tool_calls == 0
+
     def test_aplan_with_remaining_tool_calls(self, mock_agent):
         """Test aplan method when there are remaining tool calls."""
         mock_agent.generate_obs = Mock()
@@ -451,6 +480,34 @@ class TestReWOOReasoning:
         reasoning = ReWOOReasoning(mock_agent)
         reasoning.aexecute_tool_call = AsyncMock(
             return_value=Plan(step=1, llm_plan=mock_plan_without_tool_calls)
+        )
+
+        result = asyncio.run(reasoning.aplan("test prompt"))
+
+        assert isinstance(result, Plan)
+        assert reasoning.remaining_tool_calls == 0
+
+    def test_aplan_with_tool_calls_set_to_none(self, llm_response_factory, mock_agent):
+        """Test aplan method when execution returns ``tool_calls=None``."""
+        mock_agent.agenerate_obs = AsyncMock(
+            return_value=Observation(step=1, self_state={}, local_state={})
+        )
+        mock_agent.memory = Mock()
+        mock_agent.memory.format_long_term.return_value = "Long term memory"
+        mock_agent.memory.format_short_term.return_value = "Short term memory"
+        mock_agent.memory.add_to_memory = Mock()
+        mock_agent.llm = Mock()
+        mock_agent.tool_manager = Mock()
+        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+
+        mock_plan_response = llm_response_factory(content="Async plan content")
+        mock_agent.llm.agenerate = AsyncMock(return_value=mock_plan_response)
+
+        mock_plan_with_none_tool_calls = Mock()
+        mock_plan_with_none_tool_calls.tool_calls = None
+        reasoning = ReWOOReasoning(mock_agent)
+        reasoning.aexecute_tool_call = AsyncMock(
+            return_value=Plan(step=1, llm_plan=mock_plan_with_none_tool_calls)
         )
 
         result = asyncio.run(reasoning.aplan("test prompt"))


### PR DESCRIPTION
Fixes #253

## Summary

When CoT reasoning concludes that no action should be taken (e.g., "I choose NOT to call adopt_opinion"), the executor phase still forces a tool call because `tool_choice="required"`. This causes the LLM to pick an arbitrary tool — often an unrelated one like `move_one_step` — contradicting its own reasoning.

The same issue exists in the base `Reasoning.execute_tool_call()` and `aexecute_tool_call()` methods used by ReAct and ReWOO.

## Changes

- Changed `tool_choice="required"` to `tool_choice="auto"` in all four executor call sites (CoT sync/async, base Reasoning sync/async)
- Updated the executor system prompt to explicitly instruct the LLM that it may skip tool calls when the plan concludes no action is needed
- Updated existing test assertion to match the new `tool_choice` value

## Files changed

- `mesa_llm/reasoning/cot.py` — `plan()` and `aplan()` executor phases
- `mesa_llm/reasoning/reasoning.py` — `execute_tool_call()` and `aexecute_tool_call()`
- `tests/test_reasoning/test_reasoning.py` — updated assertion for `tool_choice`

## Tests

All 21 reasoning tests pass:
