### PR TITLE
Add Pydantic Field descriptions to improve LLM JSON schema parsing

### DIFF
--- a/mesa_llm/memory/episodic_memory.py
+++ b/mesa_llm/memory/episodic_memory.py
@@ -2,7 +2,7 @@ import json
 from collections import deque
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from mesa_llm.memory.memory import Memory, MemoryEntry, _format_message_entry
 
@@ -11,7 +11,9 @@ if TYPE_CHECKING:
 
 
 class EventGrade(BaseModel):
-    grade: int
+    grade: int = Field(
+        description="Integer score representing the importance of the event"
+    )
 
 
 def normalize_dict_values(scores: dict, min_target: float, max_target: float) -> dict:

--- a/mesa_llm/reasoning/react.py
+++ b/mesa_llm/reasoning/react.py
@@ -1,7 +1,7 @@
 import json
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from mesa_llm.reasoning.reasoning import Observation, Plan, Reasoning
 
@@ -10,8 +10,10 @@ if TYPE_CHECKING:
 
 
 class ReActOutput(BaseModel):
-    reasoning: str
-    action: str
+    reasoning: str = Field(
+        description="Step-by-step reasoning about the situation based on memory and observation"
+    )
+    action: str = Field(description="The specific action to take without using tools")
 
 
 class ReActReasoning(Reasoning):

--- a/tests/test_memory/test_episodic_memory.py
+++ b/tests/test_memory/test_episodic_memory.py
@@ -4,7 +4,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from mesa_llm.memory.episodic_memory import EpisodicMemory, normalize_dict_values
+from mesa_llm.memory.episodic_memory import (
+    EpisodicMemory,
+    EventGrade,
+    normalize_dict_values,
+)
 from mesa_llm.memory.memory import MemoryEntry
 
 
@@ -37,6 +41,14 @@ def test_normalize_dict_floats_logic_when_empty():
 
 class TestEpisodicMemory:
     """Core functionality test"""
+
+    def test_event_grade_schema_includes_field_description(self):
+        """Structured output schema should keep the grading instructions."""
+        schema = EventGrade.model_json_schema()
+
+        assert schema["properties"]["grade"]["description"] == (
+            "Integer score representing the importance of the event"
+        )
 
     def test_memory_init(self, episodic_mock_agent):
         """Test EpisodicMemory class initialization with defaults and custom values"""

--- a/tests/test_reasoning/test_react.py
+++ b/tests/test_reasoning/test_react.py
@@ -22,6 +22,17 @@ class TestReActOutput:
         assert output.reasoning == "I need to move to a better position"
         assert output.action == "move_north"
 
+    def test_react_output_schema_includes_field_descriptions(self):
+        """Structured output schema should keep the field guidance text."""
+        schema = ReActOutput.model_json_schema()
+
+        assert schema["properties"]["reasoning"]["description"] == (
+            "Step-by-step reasoning about the situation based on memory and observation"
+        )
+        assert schema["properties"]["action"]["description"] == (
+            "The specific action to take without using tools"
+        )
+
 
 class TestReActReasoning:
     """Test the ReActReasoning class."""


### PR DESCRIPTION
**Summary**
This PR adds explicit Pydantic `Field(description="...")` definitions to the `ReActOutput` and `EventGrade` models.

**Why this is important**
When Pydantic models are converted into JSON Schemas (for LiteLLM tool-calling or structured outputs), these field descriptions are injected directly into the prompt's schema framework. 

While large models (like GPT-4) can often infer the required output just from variable names, smaller local models (like Llama-3 or Mistral via Ollama) often struggle. By supplying explicit field instructions, we significantly reduce misformatted JSON outputs, minimize hallucinations, and make `mesa-llm` far more reliable when users opt for local model providers.