### PR TITLE
fix: raise TypeError for invalid prompt types in _build_messages()

### DIFF
--- a/mesa_llm/module_llm.py
+++ b/mesa_llm/module_llm.py
@@ -126,6 +126,20 @@ class ModuleLLM:
             if isinstance(prompt, str):
                 messages.append({"role": "user", "content": prompt})
             elif isinstance(prompt, list):
+                invalid_prompt = next(
+                    (
+                        (index, value)
+                        for index, value in enumerate(prompt)
+                        if not isinstance(value, str)
+                    ),
+                    None,
+                )
+                if invalid_prompt is not None:
+                    index, value = invalid_prompt
+                    raise TypeError(
+                        f"Invalid prompt list element at index {index}: "
+                        f"type '{type(value).__name__}'. Expected str."
+                    )
                 messages.extend([{"role": "user", "content": p} for p in prompt])
             else:
                 raise TypeError(

--- a/mesa_llm/module_llm.py
+++ b/mesa_llm/module_llm.py
@@ -122,13 +122,16 @@ class ModuleLLM:
         ) or ""
         messages.append({"role": "system", "content": system_content})
 
-        if prompt:
+        if prompt is not None:
             if isinstance(prompt, str):
                 messages.append({"role": "user", "content": prompt})
             elif isinstance(prompt, list):
-                # Use extend to add all prompts from the list
                 messages.extend([{"role": "user", "content": p} for p in prompt])
-
+            else:
+                raise TypeError(
+                    f"Invalid prompt type '{type(prompt).__name__}'. "
+                    "Expected str, list[str], or None."
+                )
         return messages
 
     def _build_rate_limit_error(self, error: RateLimitError) -> RateLimitError:

--- a/tests/test_module_llm.py
+++ b/tests/test_module_llm.py
@@ -92,6 +92,10 @@ class TestModuleLLM:
         messages = llm._build_messages(prompt=None)
         assert messages == [{"role": "system", "content": ""}]
 
+        # Test _build_messages with invalid prompt type raises TypeError
+        with pytest.raises(TypeError, match="Invalid prompt type"):
+            llm._build_messages(prompt=123)
+
     def test_model_name_validity(self):
         # Test initialization with invalid model format
 

--- a/tests/test_module_llm.py
+++ b/tests/test_module_llm.py
@@ -96,6 +96,10 @@ class TestModuleLLM:
         with pytest.raises(TypeError, match="Invalid prompt type"):
             llm._build_messages(prompt=123)
 
+        # Test _build_messages with non-string list element raises TypeError
+        with pytest.raises(TypeError, match="Invalid prompt list element"):
+            llm._build_messages(prompt=["valid", 123])
+
     def test_model_name_validity(self):
         # Test initialization with invalid model format
 


### PR DESCRIPTION
Fixes #304

When an invalid type like an integer is put inside  to _build_messages(), 
the function was tending to  silently ignoring the issue  and returning only the system 
message with no error or warning. This could cause confusing LLM 
behavior which would have been hard to debug.

This PR adds validation ,if the prompt type is not str, list[str], 
or None, a TypeError is raised with a clear message telling the user 
what type was passed and what types are expected.

Also changed `if prompt:` to `if prompt is not None:` so that empty 
strings are handled properly.

All 381 tests were passing.