### PR TITLE
Make LLM tool exposure explicit and configurable

### DIFF
--- a/docs/apis/module_llm.md
+++ b/docs/apis/module_llm.md
@@ -54,22 +54,38 @@ The `api_base` parameter is supported across all layers of Mesa-LLM: `ModuleLLM`
 
 ## Tool Integration
 
+For agent workflows, configure tools on `LLMAgent` instead of constructing a
+tool manager directly. `ModuleLLM` remains the lower-level generation wrapper;
+agent reasoning handles tool schemas and execution through the agent's configured
+tools.
+
 ```python
-from mesa_llm.tools.tool_manager import ToolManager
+from mesa.model import Model
 
-tool_manager = ToolManager()
-llm = ModuleLLM(llm_model="openai/gpt-4o")
+from mesa_llm.llm_agent import LLMAgent
+from mesa_llm.reasoning.cot import CoTReasoning
+from mesa_llm.tools.tool_decorator import tool
 
-# Generate with tool calling
-response = llm.generate(
-   prompt="Move to a better location",
-   tool_schema=tool_manager.get_all_tools_schema(),
-   tool_choice="auto"
+@tool
+def inspect_status(agent) -> str:
+   """Inspect status.
+   Args:
+      agent: The agent making the request (provided automatically)
+   Returns:
+      A compact status string.
+   """
+   return str(agent)
+
+model = Model()
+agent = LLMAgent(
+   model=model,
+   reasoning=CoTReasoning,
+   llm_model="openai/gpt-4o",
+   tools=[inspect_status],
 )
 
-# Handle tool calls
-if response.choices[0].message.tool_calls:
-   tool_manager.call_tools(agent=agent, llm_response=response.choices[0].message)
+plan = agent.reasoning.plan(prompt="Inspect the current status")
+agent.apply_plan(plan)
 ```
 
 ## Asynchronous Usage

--- a/docs/apis/reasoning.md
+++ b/docs/apis/reasoning.md
@@ -7,12 +7,26 @@ The reasoning system in Mesa-LLM provides different cognitive strategies for age
 ```python
 from mesa_llm.llm_agent import LLMAgent
 from mesa_llm.reasoning.cot import CoTReasoning
+from mesa_llm.tools.defaults import legacy_tools
+from mesa_llm.tools.tool_decorator import tool
+
+@tool
+def arrest_citizen(agent, citizen_id: int) -> str:
+   """Arrest a citizen in this model.
+   Args:
+      agent: The agent making the request (provided automatically)
+      citizen_id: Citizen to arrest.
+   Returns:
+      Arrest status.
+   """
+   return agent.arrest_citizen(citizen_id)
 
 class MyAgent(LLMAgent):
    def __init__(self, model, **kwargs):
       super().__init__(
             model=model,
             reasoning=CoTReasoning,  # Specify reasoning strategy
+            tools=[*legacy_tools(), arrest_citizen],
             **kwargs
       )
 
@@ -21,7 +35,7 @@ class MyAgent(LLMAgent):
       obs = self.generate_obs()
       plan = self.reasoning.plan(
             obs=obs,
-            selected_tools=["move_one_step", "speak_to"]
+            tools=["move_one_step", "speak_to"]
       )
       self.apply_plan(plan)
 
@@ -38,10 +52,12 @@ async def astep(self):
    plan = await self.reasoning.aplan(
       prompt=self.step_prompt,
       obs=obs,
-      selected_tools=["move_one_step", "arrest_citizen"]
+      tools=["move_one_step", "arrest_citizen"]
    )
    self.apply_plan(plan)
 ```
+
+Omitting per-call `tools` inherits the tools configured on the agent. Passing `tools=None` or `tools=[]` exposes no tools for that reasoning call. Passing `tools=[...]` narrows the configured set and fails fast if a named or callable tool was not configured on the agent first.
 
 ## Base abstractions
 

--- a/docs/apis/tools.md
+++ b/docs/apis/tools.md
@@ -1,80 +1,82 @@
 # Tools System
 
-The tools system in Mesa-LLM enables agents to interact with their environment and other agents through a structured function-calling interface. Tools represent the concrete actions agents can perform, from basic movement to complex domain-specific behaviors, and are automatically integrated with LLM reasoning through JSON schemas. The tools module provides decorators, managers, and built-in functionality for creating LLM-callable agent actions.
+The tools system in Mesa-LLM exposes explicit LLM-callable helper functions through JSON schemas. Tool exposure is opt-in: `LLMAgent(..., tools=None)` and `LLMAgent(..., tools=[])` expose no tools. Pass explicit callables or a tool-set factory when a simulation should expose tools.
+
+Current built-ins such as `move_one_step`, `teleport_to_location`, and `speak_to` are available only through explicit configuration such as `legacy_tools()`.
+
+## Tool Sets
+
+Tool sets are factory functions that return tuples. They are preferred over mutable constants and live in `mesa_llm.tools.defaults`.
+
+- `default_tools()` returns exactly `()` because no safe read-only built-ins are available yet.
+- `legacy_tools()` returns exactly `(move_one_step, teleport_to_location, speak_to)` for simulations migrating from old implicit built-ins.
+- `math_tools()` returns `()`.
+- `spatial_tools()` returns `()`.
+- `environment_tools()` returns `()`.
+- `social_query_tools()` returns `()`.
+- `external_tools()` returns `()`.
+
+`selected_tools` remains only as a deprecated compatibility alias for one transition window. New code should use `tools=`.
+
+`agent.tool_manager` remains only as a deprecated compatibility property. New code should configure tools with `LLMAgent(..., tools=...)` or pass per-call overrides with `reasoning.plan(..., tools=...)`.
+
+When working with a `ToolManager` directly, use `get_tools_schema(...)` to
+retrieve schemas for the configured tool set or a narrowed `tools=` selection.
+The selector accepts omitted `tools` for configured tools, `tools=None` or
+`tools=[]` for no tools, or a configured callable, string name, list, or tuple.
+`get_all_tools_schema(...)` and `get_tool_schema(...)` are deprecated
+compatibility aliases.
 
 ## Usage in Mesa Simulations
 
 ```python
 from mesa_llm.llm_agent import LLMAgent
+from mesa_llm.reasoning.cot import CoTReasoning
 from mesa_llm.tools.tool_decorator import tool
-from mesa_llm.tools.tool_manager import ToolManager
-
-# Creating custom tools
-@tool
-def change_state(agent: "LLMAgent", new_state: str) -> str:
-   """
-   Change the agent's internal state.
-
-   Args:
-      agent: The agent whose state to change (provided automatically)
-      new_state: The new state value to set
-
-   Returns:
-      Confirmation message of the state change
-   """
-   agent.internal_state.append(f"State changed to: {new_state}")
-   return f"Agent {agent.unique_id} state changed to {new_state}"
 
 @tool
-def arrest_citizen(agent: "LLMAgent", target_agent_id: int) -> str:
+def inspect_status(agent: "LLMAgent") -> str:
    """
-   Arrest a citizen agent if they are active and nearby.
+   Inspect the agent status.
 
    Args:
-      agent: The arresting agent (provided automatically)
-      target_agent_id: Unique ID of the citizen to arrest
+      agent: The agent making the request (provided automatically)
 
    Returns:
-      Result of the arrest attempt
+      A compact status string.
    """
-   target = next((a for a in agent.model.agents if a.unique_id == target_agent_id), None)
-   if target and target.state == CitizenState.ACTIVE:
-      target.jail_sentence_left = 2.0
-      target.state = CitizenState.ARRESTED
-      return f"Citizen {target_agent_id} has been arrested"
-   return f"Could not arrest citizen {target_agent_id}"
+   return f"Agent {agent.unique_id} is at {getattr(agent, 'pos', None)}"
 
-# Agent-specific tool configuration
-citizen_tool_manager = ToolManager()
-cop_tool_manager = ToolManager()
-
-class Citizen(LLMAgent):
+class MyAgent(LLMAgent):
    def __init__(self, model, **kwargs):
-      super().__init__(model, **kwargs)
-      self.tool_manager = citizen_tool_manager  # Limited tool access
+      super().__init__(
+         model=model,
+         reasoning=CoTReasoning,
+         tools=[inspect_status],
+         **kwargs,
+      )
 
-class Cop(LLMAgent):
-   def __init__(self, model, **kwargs):
-      super().__init__(model, **kwargs)
-      self.tool_manager = cop_tool_manager  # Full tool access
-
-# Tool selection in reasoning
-def step(self):
-   obs = self.generate_obs()
-   plan = self.reasoning.plan(
-      obs=obs,
-      selected_tools=["move_one_step", "change_state"]  # Restrict available tools for LLM calling
-   )
-   self.apply_plan(plan)
+   def step(self):
+      obs = self.generate_obs()
+      plan = self.reasoning.plan(obs=obs)
+      self.apply_plan(plan)
 ```
 
-## Tool manager
+Per-call `tools=` narrows the agent's configured tools. Omitting `tools` inherits the agent's configured tools; explicit `tools=None` or `tools=[]` exposes no tools for that call. A single configured callable or string name is accepted, as is a list or tuple of configured callables or names.
 
-```{eval-rst}
-.. automodule:: mesa_llm.tools.tool_manager
-   :members:
-   :undoc-members:
-   :show-inheritance:
+```python
+plan = self.reasoning.plan(obs=obs, tools=[inspect_status])
+plan_without_tools = self.reasoning.plan(obs=obs, tools=None)
+```
+
+Per-call selections are also used for execution of the returned plan. Any tool passed as `tools=[inspect_status]` must already be configured on the agent or manager; per-call `tools=[...]` cannot add unconfigured tools.
+
+To migrate code that relied on the old implicit built-ins, opt in explicitly:
+
+```python
+from mesa_llm.tools.defaults import legacy_tools
+
+agent = LLMAgent(model, reasoning=CoTReasoning, tools=legacy_tools())
 ```
 
 ## Tool decorator

--- a/docs/tutorials/first_model.md
+++ b/docs/tutorials/first_model.md
@@ -151,7 +151,7 @@ class SimpleAgent(LLMAgent):
         plan = self.reasoning.plan(
             prompt=prompt,
             obs=observation,
-            selected_tools=[]
+            tools=[]
         )
 
         print(plan)

--- a/examples/epstein_civil_violence/agents.py
+++ b/examples/epstein_civil_violence/agents.py
@@ -5,10 +5,7 @@ import mesa
 
 from mesa_llm.llm_agent import LLMAgent
 from mesa_llm.memory.st_lt_memory import STLTMemory
-from mesa_llm.tools.tool_manager import ToolManager
-
-citizen_tool_manager = ToolManager()
-cop_tool_manager = ToolManager()
+from mesa_llm.tools.defaults import legacy_tools
 
 
 class CitizenState(Enum):
@@ -64,6 +61,7 @@ class Citizen(LLMAgent, mesa.discrete_space.CellAgent):
             internal_state=internal_state,
             step_prompt=step_prompt,
             api_base=api_base,
+            tools=[*legacy_tools(), "change_state"],
         )
 
         self.hardship = self.random.random()
@@ -99,7 +97,6 @@ class Citizen(LLMAgent, mesa.discrete_space.CellAgent):
         self.internal_state.append(
             f"my current state in the simulation is {self.state}"
         )
-        self.tool_manager = citizen_tool_manager
         self.system_prompt = "You are a citizen in a country that is experiencing civil violence. You are a member of the general population, may or may not be in active rebellion. In general, more your suffering more the tendency for you to become active. You can move one step in a nearby cell or change your state."
 
     def update_estimated_arrest_probability(self):
@@ -138,7 +135,7 @@ class Citizen(LLMAgent, mesa.discrete_space.CellAgent):
             observation = self.generate_obs()
             plan = self.reasoning.plan(
                 obs=observation,
-                selected_tools=["change_state", "move_one_step"],
+                tools=["change_state", "move_one_step"],
             )
             self.apply_plan(plan)
         else:
@@ -150,7 +147,7 @@ class Citizen(LLMAgent, mesa.discrete_space.CellAgent):
             observation = self.generate_obs()
             plan = await self.reasoning.aplan(
                 obs=observation,
-                selected_tools=["change_state", "move_one_step"],
+                tools=["change_state", "move_one_step"],
             )
             self.apply_plan(plan)
         else:
@@ -198,9 +195,9 @@ class Cop(LLMAgent, mesa.discrete_space.CellAgent):
             internal_state=internal_state,
             step_prompt=step_prompt,
             api_base=api_base,
+            tools=[*legacy_tools(), "arrest_citizen"],
         )
         self.max_jail_term = max_jail_term
-        self.tool_manager = cop_tool_manager
         self.system_prompt = "You are a cop in a country that is experiencing civil violence. You are a member of the police force and your job is to arrest active citizens. You can arrest a citizen ONLY if they are active. You can move one step in a nearby cell or arrest a citizen."
 
         self.memory = STLTMemory(
@@ -218,7 +215,7 @@ class Cop(LLMAgent, mesa.discrete_space.CellAgent):
         observation = self.generate_obs()
         plan = self.reasoning.plan(
             obs=observation,
-            selected_tools=["move_one_step", "arrest_citizen"],
+            tools=["move_one_step", "arrest_citizen"],
         )
         self.apply_plan(plan)
 
@@ -230,6 +227,6 @@ class Cop(LLMAgent, mesa.discrete_space.CellAgent):
         observation = self.generate_obs()
         plan = await self.reasoning.aplan(
             obs=observation,
-            selected_tools=["move_one_step", "arrest_citizen"],
+            tools=["move_one_step", "arrest_citizen"],
         )
         self.apply_plan(plan)

--- a/examples/epstein_civil_violence/tools.py
+++ b/examples/epstein_civil_violence/tools.py
@@ -1,21 +1,14 @@
 import random
 from typing import TYPE_CHECKING
 
-from examples.epstein_civil_violence.agents import (
-    CitizenState,
-    citizen_tool_manager,
-    cop_tool_manager,
-)
+from examples.epstein_civil_violence.agents import CitizenState
 from mesa_llm.tools.tool_decorator import tool
 
 if TYPE_CHECKING:
     from mesa_llm.llm_agent import LLMAgent
 
-if TYPE_CHECKING:
-    from mesa_llm.llm_agent import LLMAgent
 
-
-@tool(tool_manager=citizen_tool_manager)
+@tool
 def change_state(agent: "LLMAgent", state: str) -> str:
     """
     Change the state of the agent. The state can be "QUIET" or "ACTIVE"
@@ -37,7 +30,7 @@ def change_state(agent: "LLMAgent", state: str) -> str:
     return f"agent {agent.unique_id} changed state to {state}."
 
 
-@tool(tool_manager=cop_tool_manager)
+@tool
 def arrest_citizen(agent: "LLMAgent", citizen_id: int) -> str:
     """
     Arrest a citizen (only if they are active).

--- a/examples/negotiation/agents.py
+++ b/examples/negotiation/agents.py
@@ -1,8 +1,5 @@
 from mesa_llm.llm_agent import LLMAgent
-from mesa_llm.tools.tool_manager import ToolManager
-
-seller_tool_manager = ToolManager()
-buyer_tool_manager = ToolManager()
+from mesa_llm.tools.defaults import legacy_tools
 
 
 def get_dialogue_history(agent, max_messages: int = 5) -> str:
@@ -87,9 +84,9 @@ class SellerAgent(LLMAgent):
             api_base=api_base,
             vision=vision,
             internal_state=internal_state,
+            tools=legacy_tools(),
         )
 
-        self.tool_manager = seller_tool_manager
         self.sales = 0
 
     def step(self):
@@ -105,9 +102,7 @@ class SellerAgent(LLMAgent):
             "Use the dialogue history to inform your next response (e.g., if you already offered a price, stick to it or negotiate)."
         )
 
-        plan = self.reasoning.plan(
-            prompt=prompt, obs=observation, selected_tools=["speak_to"]
-        )
+        plan = self.reasoning.plan(prompt=prompt, obs=observation, tools=["speak_to"])
         self.apply_plan(plan)
 
     async def astep(self):
@@ -124,7 +119,7 @@ class SellerAgent(LLMAgent):
         )
 
         plan = await self.reasoning.aplan(
-            prompt=prompt, obs=observation, selected_tools=["speak_to"]
+            prompt=prompt, obs=observation, tools=["speak_to"]
         )
         self.apply_plan(plan)
 
@@ -149,8 +144,8 @@ class BuyerAgent(LLMAgent):
             api_base=api_base,
             vision=vision,
             internal_state=internal_state,
+            tools=[*legacy_tools(), "buy_product"],
         )
-        self.tool_manager = buyer_tool_manager
         self.budget = budget
         self.products = []
 
@@ -171,7 +166,7 @@ class BuyerAgent(LLMAgent):
         plan = self.reasoning.plan(
             prompt=prompt,
             obs=observation,
-            selected_tools=["teleport_to_location", "speak_to", "buy_product"],
+            tools=["teleport_to_location", "speak_to", "buy_product"],
         )
         self.apply_plan(plan)
 
@@ -192,6 +187,6 @@ class BuyerAgent(LLMAgent):
         plan = await self.reasoning.aplan(
             prompt=prompt,
             obs=observation,
-            selected_tools=["teleport_to_location", "speak_to", "buy_product"],
+            tools=["teleport_to_location", "speak_to", "buy_product"],
         )
         self.apply_plan(plan)

--- a/examples/negotiation/tools.py
+++ b/examples/negotiation/tools.py
@@ -1,13 +1,12 @@
 from typing import TYPE_CHECKING
 
-from examples.negotiation.agents import buyer_tool_manager
 from mesa_llm.tools.tool_decorator import tool
 
 if TYPE_CHECKING:
     from mesa_llm.llm_agent import LLMAgent
 
 
-@tool(tool_manager=buyer_tool_manager)
+@tool
 def buy_product(agent: "LLMAgent", chosen_product: str, chosen_price: int) -> str:
     """
     A tool to set the brand of choice of the buyer agent. The product must be one of:

--- a/examples/sugarscrap_g1mt/agents.py
+++ b/examples/sugarscrap_g1mt/agents.py
@@ -2,10 +2,6 @@ import mesa
 
 from mesa_llm.llm_agent import LLMAgent
 from mesa_llm.memory.st_lt_memory import STLTMemory
-from mesa_llm.tools.tool_manager import ToolManager
-
-trader_tool_manager = ToolManager()
-resource_tool_manager = ToolManager()
 
 
 class Trader(LLMAgent, mesa.discrete_space.CellAgent):
@@ -33,6 +29,7 @@ class Trader(LLMAgent, mesa.discrete_space.CellAgent):
             internal_state=internal_state,
             step_prompt=step_prompt,
             api_base=api_base,
+            tools=["move_to_best_resource", "propose_trade"],
         )
         self.sugar = sugar
         self.spice = spice
@@ -48,8 +45,6 @@ class Trader(LLMAgent, mesa.discrete_space.CellAgent):
             llm_model=llm_model,
             api_base=api_base,
         )
-
-        self.tool_manager = trader_tool_manager
 
         self.system_prompt = (
             "You are a Trader agent in a Sugarscape simulation. "
@@ -117,7 +112,7 @@ class Trader(LLMAgent, mesa.discrete_space.CellAgent):
 
         plan = self.reasoning.plan(
             obs=observation,
-            selected_tools=["move_to_best_resource", "propose_trade"],
+            tools=["move_to_best_resource", "propose_trade"],
         )
 
         self.apply_plan(plan)
@@ -136,7 +131,7 @@ class Trader(LLMAgent, mesa.discrete_space.CellAgent):
 
         plan = await self.reasoning.aplan(
             obs=observation,
-            selected_tools=["move_to_best_resource", "propose_trade"],
+            tools=["move_to_best_resource", "propose_trade"],
         )
         self.apply_plan(plan)
 
@@ -153,8 +148,6 @@ class Resource(mesa.discrete_space.CellAgent):
         self.type = type
 
         self.internal_state = []
-
-        self.tool_manager = resource_tool_manager
 
     def get_trade(self):
         return []

--- a/examples/sugarscrap_g1mt/tools.py
+++ b/examples/sugarscrap_g1mt/tools.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING
 from examples.sugarscrap_g1mt.agents import (
     Resource,
     Trader,
-    trader_tool_manager,
 )
 from mesa_llm.tools.tool_decorator import tool
 
@@ -11,7 +10,7 @@ if TYPE_CHECKING:
     from mesa_llm.llm_agent import LLMAgent
 
 
-@tool(tool_manager=trader_tool_manager)
+@tool
 def move_to_best_resource(agent: "LLMAgent") -> str:
     """
     Move the agent to the best resource cell within its vision range.
@@ -93,7 +92,7 @@ def move_to_best_resource(agent: "LLMAgent") -> str:
     )
 
 
-@tool(tool_manager=trader_tool_manager)
+@tool
 def propose_trade(
     agent: "LLMAgent", other_agent_id: int, sugar_amount: int, spice_amount: int
 ) -> str:

--- a/mesa_llm/__init__.py
+++ b/mesa_llm/__init__.py
@@ -9,6 +9,15 @@ from .parallel_stepping import (
 )
 from .reasoning.reasoning import Observation, Plan
 from .recording.record_model import record_model
+from .tools.defaults import (
+    default_tools,
+    environment_tools,
+    external_tools,
+    legacy_tools,
+    math_tools,
+    social_query_tools,
+    spatial_tools,
+)
 from .tools.tool_manager import ToolManager
 
 # Enable automatic parallel stepping when mesa_llm is imported
@@ -18,8 +27,15 @@ __all__ = [
     "Observation",
     "Plan",
     "ToolManager",
+    "default_tools",
     "enable_automatic_parallel_stepping",
+    "environment_tools",
+    "external_tools",
+    "legacy_tools",
+    "math_tools",
     "record_model",
+    "social_query_tools",
+    "spatial_tools",
     "step_agents_parallel",
     "step_agents_parallel_sync",
 ]

--- a/mesa_llm/llm_agent.py
+++ b/mesa_llm/llm_agent.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import warnings
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from mesa.agent import Agent
@@ -20,6 +21,7 @@ from mesa_llm import Plan
 from mesa_llm.memory.st_lt_memory import STLTMemory
 from mesa_llm.module_llm import ModuleLLM
 from mesa_llm.reasoning.reasoning import (
+    _UNSET,
     Observation,
     Reasoning,
 )
@@ -49,11 +51,14 @@ class LLMAgent(Agent):
             the agent each step.
         api_base (str | None): Optional custom LiteLLM-compatible base URL for
             self-hosted or remote inference endpoints.
+        tools (list[Callable | str] | tuple[Callable | str, ...] | None):
+            Explicit tools exposed to this agent. ``None`` and ``[]`` expose
+            no tools; pass a tool-set factory such as ``legacy_tools()`` to
+            opt in to compatibility built-ins.
 
     Attributes:
         llm (ModuleLLM): The internal LLM interface used by the agent.
         memory (Memory | None): The memory module attached to this agent, if any.
-        tool_manager (ToolManager): The tool registry available to the agent.
     """
 
     def __init__(
@@ -66,6 +71,7 @@ class LLMAgent(Agent):
         internal_state: list[str] | str | None = None,
         step_prompt: str | None = None,
         api_base: str | None = None,
+        tools: list[Callable | str] | tuple[Callable | str, ...] | None = None,
     ):
         super().__init__(model=model)
 
@@ -83,7 +89,7 @@ class LLMAgent(Agent):
             api_base=api_base,
         )
 
-        self.tool_manager = ToolManager()
+        self._tool_manager = ToolManager(tools=tools)
         self.vision = vision
         self.reasoning = reasoning(agent=self)
         self.system_prompt = system_prompt
@@ -113,6 +119,26 @@ class LLMAgent(Agent):
     def system_prompt(self, value: str | None):
         self.llm.system_prompt = value
 
+    @property
+    def tool_manager(self) -> ToolManager:
+        warnings.warn(
+            "`agent.tool_manager` is deprecated; configure tools with "
+            "`LLMAgent(..., tools=...)` and treat the manager as internal.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._tool_manager
+
+    @tool_manager.setter
+    def tool_manager(self, value: ToolManager):
+        warnings.warn(
+            "`agent.tool_manager = ...` is deprecated; pass tools explicitly "
+            "or assign `agent._tool_manager` only inside framework internals.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self._tool_manager = value
+
     def _format_message_status(
         self, message: str, delivered_ids: list[int], skipped_ids: list[int]
     ) -> str:
@@ -134,9 +160,15 @@ class LLMAgent(Agent):
         """
         self._current_plan = plan
 
-        tool_call_resp = await self.tool_manager.acall_tools(
-            agent=self, llm_response=plan.llm_plan
-        )
+        plan_tools = getattr(plan, "tools", _UNSET)
+        if plan_tools is _UNSET:
+            tool_call_resp = await self._tool_manager.acall_tools(
+                agent=self, llm_response=plan.llm_plan
+            )
+        else:
+            tool_call_resp = await self._tool_manager.acall_tools(
+                agent=self, llm_response=plan.llm_plan, tools=plan_tools
+            )
 
         await self.memory.aadd_to_memory(
             type="action",
@@ -158,9 +190,15 @@ class LLMAgent(Agent):
         self._current_plan = plan
 
         # Execute tool calls
-        tool_call_resp = self.tool_manager.call_tools(
-            agent=self, llm_response=plan.llm_plan
-        )
+        plan_tools = getattr(plan, "tools", _UNSET)
+        if plan_tools is _UNSET:
+            tool_call_resp = self._tool_manager.call_tools(
+                agent=self, llm_response=plan.llm_plan
+            )
+        else:
+            tool_call_resp = self._tool_manager.call_tools(
+                agent=self, llm_response=plan.llm_plan, tools=plan_tools
+            )
 
         # Add to memory
         self.memory.add_to_memory(

--- a/mesa_llm/reasoning/cot.py
+++ b/mesa_llm/reasoning/cot.py
@@ -1,6 +1,12 @@
 from typing import TYPE_CHECKING
 
-from mesa_llm.reasoning.reasoning import Observation, Plan, Reasoning
+from mesa_llm.reasoning.reasoning import (
+    _UNSET,
+    Observation,
+    Plan,
+    Reasoning,
+    ToolSelection,
+)
 
 if TYPE_CHECKING:
     from mesa_llm.llm_agent import LLMAgent
@@ -14,8 +20,8 @@ class CoTReasoning(Reasoning):
         - **agent** (LLMAgent reference)
 
     Methods:
-        - **plan(obs, ttl=1, prompt=None, selected_tools=None, tool_calls="auto")** → *Plan* - Generate synchronous plan with CoT reasoning
-        - **async aplan(obs, ttl=1, prompt=None, selected_tools=None, tool_calls="auto")** → *Plan* - Generate asynchronous plan with CoT reasoning
+        - **plan(obs, ttl=1, prompt=None, tools=<inherit>, tool_calls="auto")** → *Plan* - Generate synchronous plan with CoT reasoning
+        - **async aplan(obs, ttl=1, prompt=None, tools=<inherit>, tool_calls="auto")** → *Plan* - Generate asynchronous plan with CoT reasoning
 
     Reasoning Format:
         Thought 1: [Initial reasoning based on observation]
@@ -99,17 +105,18 @@ class CoTReasoning(Reasoning):
         prompt: str | None = None,
         obs: Observation | None = None,
         ttl: int = 1,
-        selected_tools: list[str] | None = None,
+        tools: ToolSelection | object = _UNSET,
         tool_calls: str | None = "auto",
+        selected_tools: ToolSelection | object = _UNSET,
     ) -> Plan:
         """
         Plan the next (CoT) action based on the current observation and the
         agent's memory.
 
-        ``selected_tools`` is forwarded to ``ToolManager.get_all_tools_schema()``.
-        Omitting it or passing ``None`` uses the default behavior of exposing
-        all tools, ``[]`` exposes no tools, and a non-empty list restricts
-        planning/execution to the named tools.
+        ``tools`` controls provider tool exposure. Omitting it inherits the
+        agent's configured tools. Explicit ``None`` or ``[]`` exposes no tools.
+        A callable, string name, or sequence exposes exactly those configured
+        tools.
 
         ``tool_calls`` controls the execution-phase LiteLLM ``tool_choice``.
         The reasoning pass still keeps tool use disabled with ``"none"``.
@@ -134,12 +141,13 @@ class CoTReasoning(Reasoning):
         if obs is None:
             obs = self.agent.generate_obs()
 
+        tools = self._resolve_tools_argument(tools, selected_tools)
         llm = self.agent.llm
         system_prompt = self.get_cot_system_prompt(obs)
 
         rsp = llm.generate(
             prompt=prompt,
-            tool_schema=self.agent.tool_manager.get_all_tools_schema(selected_tools),
+            tool_schema=self._get_tools_schema(tools),
             tool_choice="none",
             system_prompt=system_prompt,
         )
@@ -152,12 +160,10 @@ class CoTReasoning(Reasoning):
         # Pass plan content to agent for display
         if hasattr(self.agent, "_step_display_data"):
             self.agent._step_display_data["plan_content"] = chaining_message
-        cot_plan = self.execute_tool_call(
-            chaining_message,
-            selected_tools=selected_tools,
-            ttl=ttl,
-            tool_calls=tool_calls,
-        )
+        execute_kwargs = {"ttl": ttl, "tool_calls": tool_calls}
+        if tools is not _UNSET:
+            execute_kwargs["tools"] = tools
+        cot_plan = self.execute_tool_call(chaining_message, **execute_kwargs)
 
         return cot_plan
 
@@ -166,16 +172,14 @@ class CoTReasoning(Reasoning):
         prompt: str | None = None,
         obs: Observation | None = None,
         ttl: int = 1,
-        selected_tools: list[str] | None = None,
+        tools: ToolSelection | object = _UNSET,
         tool_calls: str | None = "auto",
+        selected_tools: ToolSelection | object = _UNSET,
     ) -> Plan:
         """
         Asynchronous version of plan() method for parallel planning.
 
-        ``selected_tools`` follows the same contract as ``plan()``: omitting
-        it or passing ``None`` uses the default behavior of exposing all
-        tools, ``[]`` exposes no tools, and a non-empty list restricts
-        planning/execution to the named tools.
+        ``tools`` follows the same contract as ``plan()``.
 
         ``tool_calls`` controls the execution-phase LiteLLM ``tool_choice``.
         The reasoning pass still keeps tool use disabled with ``"none"``.
@@ -200,12 +204,13 @@ class CoTReasoning(Reasoning):
         if obs is None:
             obs = await self.agent.agenerate_obs()
 
+        tools = self._resolve_tools_argument(tools, selected_tools)
         llm = self.agent.llm
         system_prompt = self.get_cot_system_prompt(obs)
 
         rsp = await llm.agenerate(
             prompt=prompt,
-            tool_schema=self.agent.tool_manager.get_all_tools_schema(selected_tools),
+            tool_schema=self._get_tools_schema(tools),
             tool_choice="none",
             system_prompt=system_prompt,
         )
@@ -218,11 +223,9 @@ class CoTReasoning(Reasoning):
         # Pass plan content to agent for display
         if hasattr(self.agent, "_step_display_data"):
             self.agent._step_display_data["plan_content"] = chaining_message
-        cot_plan = await self.aexecute_tool_call(
-            chaining_message,
-            selected_tools=selected_tools,
-            ttl=ttl,
-            tool_calls=tool_calls,
-        )
+        execute_kwargs = {"ttl": ttl, "tool_calls": tool_calls}
+        if tools is not _UNSET:
+            execute_kwargs["tools"] = tools
+        cot_plan = await self.aexecute_tool_call(chaining_message, **execute_kwargs)
 
         return cot_plan

--- a/mesa_llm/reasoning/react.py
+++ b/mesa_llm/reasoning/react.py
@@ -3,7 +3,13 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 
-from mesa_llm.reasoning.reasoning import Observation, Plan, Reasoning
+from mesa_llm.reasoning.reasoning import (
+    _UNSET,
+    Observation,
+    Plan,
+    Reasoning,
+    ToolSelection,
+)
 
 if TYPE_CHECKING:
     from mesa_llm.llm_agent import LLMAgent
@@ -24,8 +30,8 @@ class ReActReasoning(Reasoning):
         - **agent** (LLMAgent reference)
 
     Methods:
-        - **plan(prompt, obs=None, ttl=1, selected_tools=None, tool_calls="auto")** → *Plan* - Generate synchronous plan with ReAct reasoning
-        - **async aplan(prompt, obs=None, ttl=1, selected_tools=None, tool_calls="auto")** → *Plan* - Generate asynchronous plan with ReAct reasoning
+        - **plan(prompt, obs=None, ttl=1, tools=<inherit>, tool_calls="auto")** → *Plan* - Generate synchronous plan with ReAct reasoning
+        - **async aplan(prompt, obs=None, ttl=1, tools=<inherit>, tool_calls="auto")** → *Plan* - Generate asynchronous plan with ReAct reasoning
     """
 
     def __init__(self, agent: "LLMAgent"):
@@ -70,17 +76,18 @@ class ReActReasoning(Reasoning):
         prompt: str | None = None,
         obs: Observation | None = None,
         ttl: int = 1,
-        selected_tools: list[str] | None = None,
+        tools: ToolSelection | object = _UNSET,
         tool_calls: str | None = "auto",
+        selected_tools: ToolSelection | object = _UNSET,
     ) -> Plan:
         """
         Plan the next (ReAct) action based on the current observation and the
         agent's memory.
 
-        ``selected_tools`` is forwarded to ``ToolManager.get_all_tools_schema()``.
-        Omitting it or passing ``None`` uses the default behavior of exposing
-        all tools, ``[]`` exposes no tools, and a non-empty list restricts
-        planning/execution to the named tools.
+        ``tools`` controls provider tool exposure. Omitting it inherits the
+        agent's configured tools. Explicit ``None`` or ``[]`` exposes no tools.
+        A callable, string name, or sequence exposes exactly those configured
+        tools.
 
         ``tool_calls`` controls the execution-phase LiteLLM ``tool_choice``.
         The reasoning pass still keeps tool use disabled with ``"none"``.
@@ -111,14 +118,13 @@ class ReActReasoning(Reasoning):
         else:
             raise ValueError("No prompt provided and agent.step_prompt is None.")
 
-        selected_tools_schema = self.agent.tool_manager.get_all_tools_schema(
-            selected_tools
-        )
+        tools = self._resolve_tools_argument(tools, selected_tools)
+        tools_schema = self._get_tools_schema(tools)
 
         # ---------------- generate the plan ----------------
         rsp = self.agent.llm.generate(
             prompt=prompt_list,
-            tool_schema=selected_tools_schema,
+            tool_schema=tools_schema,
             tool_choice="none",
             response_format=ReActOutput,
             system_prompt=react_system_prompt,
@@ -129,11 +135,11 @@ class ReActReasoning(Reasoning):
         self.agent.memory.add_to_memory(type="plan", content=formatted_response)
 
         # ---------------- execute the plan ----------------
+        execute_kwargs = {"ttl": ttl, "tool_calls": tool_calls}
+        if tools is not _UNSET:
+            execute_kwargs["tools"] = tools
         react_plan = self.execute_tool_call(
-            formatted_response["action"],
-            selected_tools=selected_tools,
-            ttl=ttl,
-            tool_calls=tool_calls,
+            formatted_response["action"], **execute_kwargs
         )
 
         return react_plan
@@ -143,16 +149,14 @@ class ReActReasoning(Reasoning):
         prompt: str | None = None,
         obs: Observation | None = None,
         ttl: int = 1,
-        selected_tools: list[str] | None = None,
+        tools: ToolSelection | object = _UNSET,
         tool_calls: str | None = "auto",
+        selected_tools: ToolSelection | object = _UNSET,
     ) -> Plan:
         """
         Asynchronous version of plan() method for parallel planning.
 
-        ``selected_tools`` follows the same contract as ``plan()``: omitting
-        it or passing ``None`` uses the default behavior of exposing all
-        tools, ``[]`` exposes no tools, and a non-empty list restricts
-        planning/execution to the named tools.
+        ``tools`` follows the same contract as ``plan()``.
 
         ``tool_calls`` controls the execution-phase LiteLLM ``tool_choice``.
         The reasoning pass still keeps tool use disabled with ``"none"``.
@@ -182,15 +186,14 @@ class ReActReasoning(Reasoning):
         else:
             raise ValueError("No prompt provided and agent.step_prompt is None.")
 
-        selected_tools_schema = self.agent.tool_manager.get_all_tools_schema(
-            selected_tools
-        )
+        tools = self._resolve_tools_argument(tools, selected_tools)
+        tools_schema = self._get_tools_schema(tools)
 
         # ---------------- generate the plan ----------------
 
         rsp = await self.agent.llm.agenerate(
             prompt=prompt_list,
-            tool_schema=selected_tools_schema,
+            tool_schema=tools_schema,
             tool_choice="none",
             response_format=ReActOutput,
             system_prompt=react_system_prompt,
@@ -201,11 +204,11 @@ class ReActReasoning(Reasoning):
         await self.agent.memory.aadd_to_memory(type="plan", content=formatted_response)
 
         # ---------------- execute the plan ----------------
+        execute_kwargs = {"ttl": ttl, "tool_calls": tool_calls}
+        if tools is not _UNSET:
+            execute_kwargs["tools"] = tools
         react_plan = await self.aexecute_tool_call(
-            formatted_response["action"],
-            selected_tools=selected_tools,
-            ttl=ttl,
-            tool_calls=tool_calls,
+            formatted_response["action"], **execute_kwargs
         )
 
         return react_plan

--- a/mesa_llm/reasoning/reasoning.py
+++ b/mesa_llm/reasoning/reasoning.py
@@ -1,9 +1,17 @@
+import warnings
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from mesa_llm.llm_agent import LLMAgent
+    from mesa_llm.tools.tool_manager import ToolManager
+
+
+_UNSET = object()
+ToolRef = Callable | str
+ToolSelection = ToolRef | list[ToolRef] | tuple[ToolRef, ...] | None
 
 
 @dataclass
@@ -44,6 +52,7 @@ class Plan:
     step: int  # step when the plan was generated
     llm_plan: Any  # complete LLM response message object (contains both content and tool_calls)
     ttl: int = 1  # steps until planning again (ReWOO sets >1)
+    tools: ToolSelection | object = _UNSET
 
     def __str__(self) -> str:
         # Extract content from the message object for display
@@ -63,8 +72,8 @@ class Reasoning(ABC):
         - **agent** (LLMAgent reference)
 
     Methods:
-        - **abstract plan(prompt, obs=None, ttl=1, selected_tools=None, tool_calls="auto")** → *Plan* - Generate synchronous plan
-        - **async aplan(prompt, obs=None, ttl=1, selected_tools=None, tool_calls="auto")** → *Plan* - Generate asynchronous plan
+        - **abstract plan(prompt, obs=None, ttl=1, tools=<inherit>, tool_calls="auto")** → *Plan* - Generate synchronous plan
+        - **async aplan(prompt, obs=None, ttl=1, tools=<inherit>, tool_calls="auto")** → *Plan* - Generate asynchronous plan
 
 
     Reasoning Flow:
@@ -78,14 +87,43 @@ class Reasoning(ABC):
     def __init__(self, agent: "LLMAgent"):
         self.agent = agent
 
+    def _tool_manager(self) -> "ToolManager":
+        manager = getattr(self.agent, "__dict__", {}).get("_tool_manager")
+        if manager is not None:
+            return manager
+        return self.agent.tool_manager
+
+    def _resolve_tools_argument(
+        self,
+        tools: ToolSelection | object = _UNSET,
+        selected_tools: ToolSelection | object = _UNSET,
+    ) -> ToolSelection | object:
+        if selected_tools is not _UNSET:
+            warnings.warn(
+                "`selected_tools` is deprecated; use `tools=` instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            if tools is not _UNSET:
+                raise ValueError("Use either `tools` or `selected_tools`, not both.")
+            tools = selected_tools
+        return tools
+
+    def _get_tools_schema(self, tools: ToolSelection | object = _UNSET) -> list[dict]:
+        manager = self._tool_manager()
+        if tools is _UNSET:
+            return manager.get_tools_schema()
+        return manager.get_tools_schema(tools=tools)
+
     @abstractmethod
     def plan(
         self,
         prompt: str | None = None,
         obs: Observation | None = None,
         ttl: int = 1,
-        selected_tools: list[str] | None = None,
+        tools: ToolSelection | object = _UNSET,
         tool_calls: str | None = "auto",
+        selected_tools: ToolSelection | object = _UNSET,
     ) -> Plan:
         """Generate a plan for the next action.
 
@@ -93,11 +131,10 @@ class Reasoning(ABC):
             prompt: Optional prompt override for the reasoning strategy.
             obs: Optional observation to plan against.
             ttl: Time-to-live for the generated plan.
-            selected_tools: Optional explicit tool allowlist forwarded to
-                ``ToolManager.get_all_tools_schema()``. If omitted or ``None``,
-                the default behavior exposes all tools. ``[]`` exposes no
-                tools, and a non-empty list restricts planning/execution to
-                the named tools.
+            tools: Optional explicit tool selector. If omitted, the reasoning call
+                inherits the agent's configured tools. Explicit ``None`` or
+                ``[]`` exposes no tools, and a callable, string name, or
+                sequence exposes exactly those configured tools.
             tool_calls: Execution-phase LiteLLM ``tool_choice`` override used
                 when converting the natural-language plan into tool calls.
                 Planning still keeps tool use disabled.
@@ -123,42 +160,44 @@ class Reasoning(ABC):
         prompt: str | None = None,
         obs: Observation | None = None,
         ttl: int = 1,
-        selected_tools: list[str] | None = None,
+        tools: ToolSelection | object = _UNSET,
         tool_calls: str | None = "auto",
+        selected_tools: ToolSelection | object = _UNSET,
     ) -> Plan:
         """
         Asynchronous version of plan() method for parallel planning.
         Default implementation calls the synchronous plan() method.
 
-        ``selected_tools`` follows the same contract as ``plan()``: omitting
-        it or passing ``None`` uses the default behavior of exposing all
-        tools, ``[]`` exposes no tools, and a non-empty list restricts
-        planning/execution to the named tools.
+        ``tools`` follows the same contract as ``plan()``: omitted inherits
+        the agent's configured tools, explicit ``None`` or ``[]`` exposes no
+        tools, and a callable, string name, or sequence exposes exactly those
+        configured tools.
         """
         return self.plan(
             prompt=prompt,
             obs=obs,
             ttl=ttl,
-            selected_tools=selected_tools,
+            tools=tools,
             tool_calls=tool_calls,
+            selected_tools=selected_tools,
         )
 
     def execute_tool_call(
         self,
         chaining_message,
-        selected_tools: list[str] | None = None,
+        tools: ToolSelection | object = _UNSET,
         ttl: int = 1,
         tool_calls: str | None = "auto",
+        selected_tools: ToolSelection | object = _UNSET,
     ):
         """Turn a natural-language plan into tool calls.
 
         Args:
             chaining_message: Natural-language plan or action text to execute.
-            selected_tools: Optional explicit tool allowlist forwarded to
-                ``ToolManager.get_all_tools_schema()``. Omitting it or passing
-                ``None`` uses the default behavior of exposing all tools,
-                ``[]`` exposes no tools, and a non-empty list restricts
-                execution to the named tools.
+            tools: Optional explicit tool selector. If omitted, the execution call
+                inherits the agent's configured tools. Explicit ``None`` or
+                ``[]`` exposes no tools, and a callable, string name, or
+                sequence exposes exactly those configured tools.
             ttl: Time-to-live for the returned plan.
             tool_calls: LiteLLM ``tool_choice`` passed to the execution call.
                 Supported values in Mesa-LLM are:
@@ -180,16 +219,20 @@ class Reasoning(ABC):
             "You are an executor that executes the plan given to you in the prompt through tool calls. "
             "If the plan concludes that no action should be taken, do not call any tool."
         )
+        tools = self._resolve_tools_argument(tools, selected_tools)
         rsp = self.agent.llm.generate(
             prompt=chaining_message,
-            tool_schema=self.agent.tool_manager.get_all_tools_schema(
-                selected_tools=selected_tools
-            ),
+            tool_schema=self._get_tools_schema(tools),
             tool_choice=tool_calls,
             system_prompt=system_prompt,
         )
         response_message = rsp.choices[0].message
-        plan = Plan(step=self.agent.model.steps, llm_plan=response_message, ttl=ttl)
+        plan = Plan(
+            step=self.agent.model.steps,
+            llm_plan=response_message,
+            ttl=ttl,
+            tools=tools,
+        )
         self.agent.memory.add_to_memory(
             type="plan_execution", content={"content": str(plan)}
         )
@@ -199,32 +242,37 @@ class Reasoning(ABC):
     async def aexecute_tool_call(
         self,
         chaining_message,
-        selected_tools: list[str] | None = None,
+        tools: ToolSelection | object = _UNSET,
         ttl: int = 1,
         tool_calls: str | None = "auto",
+        selected_tools: ToolSelection | object = _UNSET,
     ):
         """
         Asynchronous version of execute_tool_call() method.
 
-        ``selected_tools`` follows the same contract as
-        ``execute_tool_call()``: omitting it or passing ``None`` uses the
-        default behavior of exposing all tools, ``[]`` exposes no tools, and
-        a non-empty list restricts execution to the named tools.
+        ``tools`` follows the same contract as ``execute_tool_call()``:
+        omitted inherits the agent's configured tools, explicit ``None`` or
+        ``[]`` exposes no tools, and a callable, string name, or sequence
+        exposes exactly those configured tools.
         """
         system_prompt = (
             "You are an executor that executes the plan given to you in the prompt through tool calls. "
             "If the plan concludes that no action should be taken, do not call any tool."
         )
+        tools = self._resolve_tools_argument(tools, selected_tools)
         rsp = await self.agent.llm.agenerate(
             prompt=chaining_message,
-            tool_schema=self.agent.tool_manager.get_all_tools_schema(
-                selected_tools=selected_tools
-            ),
+            tool_schema=self._get_tools_schema(tools),
             tool_choice=tool_calls,
             system_prompt=system_prompt,
         )
         response_message = rsp.choices[0].message
-        plan = Plan(step=self.agent.model.steps, llm_plan=response_message, ttl=ttl)
+        plan = Plan(
+            step=self.agent.model.steps,
+            llm_plan=response_message,
+            ttl=ttl,
+            tools=tools,
+        )
         await self.agent.memory.aadd_to_memory(
             type="plan_execution", content={"content": str(plan)}
         )

--- a/mesa_llm/reasoning/reasoning.py
+++ b/mesa_llm/reasoning/reasoning.py
@@ -106,7 +106,7 @@ class Reasoning(ABC):
             )
             if tools is not _UNSET:
                 raise ValueError("Use either `tools` or `selected_tools`, not both.")
-            tools = selected_tools
+            tools = _UNSET if selected_tools is None else selected_tools
         return tools
 
     def _get_tools_schema(self, tools: ToolSelection | object = _UNSET) -> list[dict]:

--- a/mesa_llm/reasoning/rewoo.py
+++ b/mesa_llm/reasoning/rewoo.py
@@ -33,6 +33,7 @@ class ReWOOReasoning(Reasoning):
         self.remaining_tool_calls = 0  # Initialize remaining tool calls
         self.current_plan: Plan | None = None
         self.current_obs: Observation | None = None
+        self.current_tools: ToolSelection | object = _UNSET
 
     def get_rewoo_system_prompt(self, obs: Observation) -> str:
         memory = getattr(self.agent, "memory", None)
@@ -150,7 +151,12 @@ class ReWOOReasoning(Reasoning):
             tool_call = [self.current_plan.tool_calls[index_of_tool]]
             current_plan = copy.copy(self.current_plan)
             current_plan.tool_calls = tool_call
-            return Plan(llm_plan=current_plan, step=self.current_obs.step, ttl=ttl)
+            return Plan(
+                llm_plan=current_plan,
+                step=self.current_obs.step,
+                ttl=ttl,
+                tools=self.current_tools,
+            )
 
         # If no prompt is provided, use the agent's default step prompt
         if prompt is None:
@@ -189,6 +195,7 @@ class ReWOOReasoning(Reasoning):
             getattr(rewoo_plan.llm_plan, "tool_calls", None) or []
         )
         self.current_plan = rewoo_plan.llm_plan
+        self.current_tools = tools
 
         return rewoo_plan
 
@@ -228,7 +235,12 @@ class ReWOOReasoning(Reasoning):
             tool_call = [self.current_plan.tool_calls[index_of_tool]]
             current_plan = copy.copy(self.current_plan)
             current_plan.tool_calls = tool_call
-            return Plan(llm_plan=current_plan, step=self.current_obs.step, ttl=ttl)
+            return Plan(
+                llm_plan=current_plan,
+                step=self.current_obs.step,
+                ttl=ttl,
+                tools=self.current_tools,
+            )
 
         # If no prompt is provided, use the agent's default step prompt
         if prompt is None:
@@ -267,5 +279,6 @@ class ReWOOReasoning(Reasoning):
             getattr(rewoo_plan.llm_plan, "tool_calls", None) or []
         )
         self.current_plan = rewoo_plan.llm_plan
+        self.current_tools = tools
 
         return rewoo_plan

--- a/mesa_llm/reasoning/rewoo.py
+++ b/mesa_llm/reasoning/rewoo.py
@@ -2,9 +2,11 @@ import copy
 from typing import TYPE_CHECKING
 
 from mesa_llm.reasoning.reasoning import (
+    _UNSET,
     Observation,
     Plan,
     Reasoning,
+    ToolSelection,
 )
 
 if TYPE_CHECKING:
@@ -22,8 +24,8 @@ class ReWOOReasoning(Reasoning):
         - **current_obs** (Observation) - Last observation used for planning
 
     Methods:
-        - **plan(prompt, obs=None, ttl=1, selected_tools=None, tool_calls="auto")** → *Plan* - Generate synchronous plan with ReWOO reasoning
-        - **async aplan(prompt, obs=None, ttl=1, selected_tools=None, tool_calls="auto")** → *Plan* - Generate asynchronous plan with ReWOO reasoning
+        - **plan(prompt, obs=None, ttl=1, tools=<inherit>, tool_calls="auto")** → *Plan* - Generate synchronous plan with ReWOO reasoning
+        - **async aplan(prompt, obs=None, ttl=1, tools=<inherit>, tool_calls="auto")** → *Plan* - Generate asynchronous plan
     """
 
     def __init__(self, agent: "LLMAgent"):
@@ -113,17 +115,18 @@ class ReWOOReasoning(Reasoning):
         prompt: str | None = None,
         obs: Observation | None = None,
         ttl: int = 1,
-        selected_tools: list[str] | None = None,
+        tools: ToolSelection | object = _UNSET,
         tool_calls: str | None = "auto",
+        selected_tools: ToolSelection | object = _UNSET,
     ) -> Plan:
         """
         Plan the next (ReWOO) action based on the current observation and the
         agent's memory.
 
-        ``selected_tools`` is forwarded to ``ToolManager.get_all_tools_schema()``.
-        Omitting it or passing ``None`` uses the default behavior of exposing
-        all tools, ``[]`` exposes no tools, and a non-empty list restricts
-        planning/execution to the named tools.
+        ``tools`` controls provider tool exposure. Omitting it inherits the
+        agent's configured tools. Explicit ``None`` or ``[]`` exposes no tools.
+        A callable, string name, or sequence exposes exactly those configured
+        tools.
 
         ``tool_calls`` controls the execution-phase LiteLLM ``tool_choice``.
         The planning pass still keeps tool use disabled with ``"none"``.
@@ -162,10 +165,11 @@ class ReWOOReasoning(Reasoning):
             self.current_obs = obs
         llm = self.agent.llm
         system_prompt = self.get_rewoo_system_prompt(self.current_obs)
+        tools = self._resolve_tools_argument(tools, selected_tools)
 
         rsp = llm.generate(
             prompt=prompt,
-            tool_schema=self.agent.tool_manager.get_all_tools_schema(selected_tools),
+            tool_schema=self._get_tools_schema(tools),
             tool_choice="none",
             system_prompt=system_prompt,
         )
@@ -174,11 +178,11 @@ class ReWOOReasoning(Reasoning):
             type="plan", content={"content": rsp.choices[0].message.content}
         )
 
+        execute_kwargs = {"ttl": ttl, "tool_calls": tool_calls}
+        if tools is not _UNSET:
+            execute_kwargs["tools"] = tools
         rewoo_plan = self.execute_tool_call(
-            rsp.choices[0].message.content,
-            selected_tools=selected_tools,
-            ttl=ttl,
-            tool_calls=tool_calls,
+            rsp.choices[0].message.content, **execute_kwargs
         )
         # Count the number of tool calls in the response and set remaining_tool_calls
         self.remaining_tool_calls = len(
@@ -193,16 +197,14 @@ class ReWOOReasoning(Reasoning):
         prompt: str | None = None,
         obs: Observation | None = None,
         ttl: int = 1,
-        selected_tools: list[str] | None = None,
+        tools: ToolSelection | object = _UNSET,
         tool_calls: str | None = "auto",
+        selected_tools: ToolSelection | object = _UNSET,
     ) -> Plan:
         """
         Asynchronous version of plan() method for parallel planning.
 
-        ``selected_tools`` follows the same contract as ``plan()``: omitting
-        it or passing ``None`` uses the default behavior of exposing all
-        tools, ``[]`` exposes no tools, and a non-empty list restricts
-        planning/execution to the named tools.
+        ``tools`` follows the same contract as ``plan()``.
 
         ``tool_calls`` controls the execution-phase LiteLLM ``tool_choice``.
         The planning pass still keeps tool use disabled with ``"none"``.
@@ -241,10 +243,11 @@ class ReWOOReasoning(Reasoning):
             self.current_obs = obs
         llm = self.agent.llm
         system_prompt = self.get_rewoo_system_prompt(self.current_obs)
+        tools = self._resolve_tools_argument(tools, selected_tools)
 
         rsp = await llm.agenerate(
             prompt=prompt,
-            tool_schema=self.agent.tool_manager.get_all_tools_schema(selected_tools),
+            tool_schema=self._get_tools_schema(tools),
             tool_choice="none",
             system_prompt=system_prompt,
         )
@@ -253,11 +256,11 @@ class ReWOOReasoning(Reasoning):
             type="plan", content={"content": rsp.choices[0].message.content}
         )
 
+        execute_kwargs = {"ttl": ttl, "tool_calls": tool_calls}
+        if tools is not _UNSET:
+            execute_kwargs["tools"] = tools
         rewoo_plan = await self.aexecute_tool_call(
-            rsp.choices[0].message.content,
-            selected_tools=selected_tools,
-            ttl=ttl,
-            tool_calls=tool_calls,
+            rsp.choices[0].message.content, **execute_kwargs
         )
         # Count the number of tool calls in the response and set remaining_tool_calls
         self.remaining_tool_calls = len(

--- a/mesa_llm/tools/defaults.py
+++ b/mesa_llm/tools/defaults.py
@@ -1,0 +1,55 @@
+"""Explicit tool-set factories for Mesa-LLM capability configuration."""
+
+from collections.abc import Callable
+
+from mesa_llm.tools.inbuilt_tools import (
+    move_one_step,
+    speak_to,
+    teleport_to_location,
+)
+
+
+def default_tools() -> tuple[Callable, ...]:
+    """Return the recommended default read-only tools."""
+    return ()
+
+
+def math_tools() -> tuple[Callable, ...]:
+    """Return math/calculation tools."""
+    return ()
+
+
+def spatial_tools() -> tuple[Callable, ...]:
+    """Return read-only spatial query tools."""
+    return ()
+
+
+def environment_tools() -> tuple[Callable, ...]:
+    """Return read-only environment/context tools."""
+    return ()
+
+
+def social_query_tools() -> tuple[Callable, ...]:
+    """Return read-only social-context query tools."""
+    return ()
+
+
+def external_tools() -> tuple[Callable, ...]:
+    """Return opt-in external tools."""
+    return ()
+
+
+def legacy_tools() -> tuple[Callable, Callable, Callable]:
+    """Return the compatibility tools for old implicit built-in behavior."""
+    return (move_one_step, teleport_to_location, speak_to)
+
+
+__all__ = [
+    "default_tools",
+    "environment_tools",
+    "external_tools",
+    "legacy_tools",
+    "math_tools",
+    "social_query_tools",
+    "spatial_tools",
+]

--- a/mesa_llm/tools/tool_decorator.py
+++ b/mesa_llm/tools/tool_decorator.py
@@ -21,8 +21,13 @@ _TOOL_CALLBACKS: list[Callable[[Callable], None]] = []
 
 
 def add_tool_callback(callback: Callable[[Callable], None]):
-    """Add a callback to be called when a new tool is registered"""
-    _TOOL_CALLBACKS.append(callback)
+    """Deprecated no-op for the old implicit global tool propagation hook."""
+    warnings.warn(
+        "`add_tool_callback` is deprecated and no longer called for bare "
+        "`@tool` registrations; configure tools explicitly instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
 
 # ---------- helper functions ----------------------------------------------------
@@ -319,11 +324,20 @@ def tool(
     ignore_agent: bool = True,
 ):
     """
-    Converts Python functions into LLM-compatible tools by automatically generating JSON schemas from type hints and docstrings. Handles parameter validation, type conversion, and integration with the global tool registry. This module automatically extracts parameter descriptions from Google-style docstrings, injects calling agents into functions expecting an `agent` parameter, and integrates with the global tool registry for automatic availability across all ToolManager instances.
+    Convert a Python function into an LLM-compatible tool.
+
+    The decorator generates a JSON schema from type hints and Google-style
+    docstrings, optionally omitting an ``agent`` parameter that Mesa-LLM injects
+    during execution. Passing ``tool_manager=`` registers the decorated function
+    directly with that manager. Bare ``@tool`` registration stores the function
+    in the global registry so callers can opt in explicitly by name or by
+    configuring a manager or agent with that tool; it does not make the tool
+    automatically available to every manager.
 
     Args:
         fn: The function to decorate.
-        tool_manager : the optional tool manager to add the function to
+        tool_manager: Optional tool manager to register the function with.
+        ignore_agent: Whether to omit the ``agent`` parameter from the schema.
 
     Returns:
         The decorated function.
@@ -386,8 +400,6 @@ def tool(
             tool_manager.register(func)
         else:
             _GLOBAL_TOOL_REGISTRY[name] = func
-            for callback in _TOOL_CALLBACKS:
-                callback(func)
 
         return func
 

--- a/mesa_llm/tools/tool_manager.py
+++ b/mesa_llm/tools/tool_manager.py
@@ -1,6 +1,7 @@
 import asyncio
 import concurrent.futures
 import contextlib
+import copy
 import inspect
 import json
 import logging
@@ -67,7 +68,7 @@ class ToolManager:
                 DeprecationWarning,
                 stacklevel=2,
             )
-            self.register_many(tuple(extra_tools.values()))
+            self.tools.update(extra_tools)
 
     def register(self, fn: Callable):
         """Register a tool function by name"""
@@ -88,9 +89,16 @@ class ToolManager:
     def _get_tool_schema(self, tool: ToolRef, schema_name: str | None = None) -> dict:
         fn = self._resolve_configured_tool_ref(tool) if isinstance(tool, str) else tool
         schema_name = schema_name or getattr(fn, "__name__", repr(fn))
-        return getattr(fn, "__tool_schema__", None) or {
-            "error": f"Tool {schema_name} missing __tool_schema__"
-        }
+        schema = getattr(fn, "__tool_schema__", None)
+        if schema is None:
+            return {"error": f"Tool {schema_name} missing __tool_schema__"}
+
+        if schema.get("function", {}).get("name") == schema_name:
+            return schema
+
+        aliased_schema = copy.deepcopy(schema)
+        aliased_schema.setdefault("function", {})["name"] = schema_name
+        return aliased_schema
 
     def get_tool_schema(self, fn: Callable, schema_name: str | None = None) -> dict:
         """Deprecated compatibility alias for the private single-tool helper."""
@@ -148,15 +156,22 @@ class ToolManager:
 
     def _resolve_configured_tool_ref(self, tool_ref: ToolRef) -> Callable:
         """Resolve per-call tool selectors against configured tools only."""
+        return self._resolve_configured_tool_item(tool_ref)[1]
+
+    def _resolve_configured_tool_item(self, tool_ref: ToolRef) -> tuple[str, Callable]:
+        """Resolve a per-call selector while preserving configured tool names."""
         if isinstance(tool_ref, str):
             if tool_ref in self.tools:
-                return self.tools[tool_ref]
+                return tool_ref, self.tools[tool_ref]
             raise self._unknown_tool_error(tool_ref)
 
         if callable(tool_ref):
             tool_name = getattr(tool_ref, "__name__", repr(tool_ref))
             if tool_name in self.tools and self.tools[tool_name] is tool_ref:
-                return self.tools[tool_name]
+                return tool_name, self.tools[tool_name]
+            for configured_name, configured_fn in self.tools.items():
+                if configured_fn is tool_ref:
+                    return configured_name, configured_fn
             raise self._unknown_tool_error(tool_name)
 
         raise self._invalid_tool_ref_error(tool_ref)
@@ -177,6 +192,12 @@ class ToolManager:
             for tool_ref in self._normalize_tool_selection(tools)
         ]
 
+    def _resolve_tool_items(self, tools: ToolSelection) -> list[tuple[str, Callable]]:
+        return [
+            self._resolve_configured_tool_item(tool_ref)
+            for tool_ref in self._normalize_tool_selection(tools)
+        ]
+
     def _get_tool_execution_map(
         self,
         tools: ToolSelection | object = _UNSET,
@@ -185,7 +206,7 @@ class ToolManager:
             return self.tools
         if tools is None:
             return {}
-        return {fn.__name__: fn for fn in self._resolve_tool_refs(tools)}
+        return dict(self._resolve_tool_items(tools))
 
     def get_tools_schema(
         self,
@@ -207,16 +228,18 @@ class ToolManager:
             )
             if tools is not _UNSET:
                 raise ValueError("Use either `tools` or `selected_tools`, not both.")
-            tools = selected_tools
+            tools = _UNSET if selected_tools is None else selected_tools
 
         if tools is _UNSET:
-            selected_fns = list(self.tools.values())
+            selected_items = list(self.tools.items())
         elif tools is None:
-            selected_fns = []
+            selected_items = []
         else:
-            selected_fns = self._resolve_tool_refs(tools)
+            selected_items = self._resolve_tool_items(tools)
 
-        return [self._get_tool_schema(fn) for fn in selected_fns]
+        return [
+            self._get_tool_schema(fn, schema_name=name) for name, fn in selected_items
+        ]
 
     def get_all_tools_schema(
         self,
@@ -232,7 +255,9 @@ class ToolManager:
         if selected_tools is not _UNSET:
             if tools is not _UNSET:
                 raise ValueError("Use either `tools` or `selected_tools`, not both.")
-            tools = selected_tools
+            tools = _UNSET if selected_tools is None else selected_tools
+        elif tools is None:
+            tools = _UNSET
         return self.get_tools_schema(tools=tools)
 
     def call(self, name: str, arguments: dict) -> str:

--- a/mesa_llm/tools/tool_manager.py
+++ b/mesa_llm/tools/tool_manager.py
@@ -4,36 +4,43 @@ import contextlib
 import inspect
 import json
 import logging
+import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ClassVar, get_type_hints
 
 from terminal_style import style
 
-from mesa_llm.tools.tool_decorator import _GLOBAL_TOOL_REGISTRY, add_tool_callback
+from mesa_llm.tools.tool_decorator import _GLOBAL_TOOL_REGISTRY
 
 if TYPE_CHECKING:
     from mesa_llm.llm_agent import LLMAgent
 
 logger = logging.getLogger(__name__)
 
+_UNSET = object()
+ToolRef = Callable | str
+ToolSelection = ToolRef | list[ToolRef] | tuple[ToolRef, ...] | None
+
 
 class ToolManager:
     """
-    Manager for registering, organizing, and executing LLM-callable tools with per-agent customization. Supports both global tool registration and per-agent tool customization while maintaining a central registry. There can be multiple instances of ToolManager for different group of agents.
+    Manager for registering, organizing, and executing explicit LLM-callable
+    tools. Bare managers expose no tools; pass ``tools=`` to configure the
+    exact capabilities a manager should expose.
 
     Attributes:
         - tools: A dictionary of tools of the form {tool_name: tool_function}. E.g. {"get_current_weather": get_current_weather}.
-        - **instances** (class-level list) - All ToolManager instances for global tool distribution
+        - **instances** (class-level list) - ToolManager instances.
 
     Methods:
         - **register(fn)** - Register tool function to this manager
         - **add_tool_to_all(fn)** - Add tool to all ToolManager instances
-        - **get_all_tools_schema(selected_tools=None)** → *list[dict]* - Get OpenAI-compatible schemas
+        - **get_tools_schema(tools=<inherit>)** → *list[dict]* - Get OpenAI-compatible schemas
         - **call_tools(agent, llm_response)** → *list[dict]* - Execute LLM-recommended tools
         - **has_tool(name)** → *bool* - Check if tool is registered
 
     Tool Execution Flow:
-        1. **Tool Registration**: Functions decorated with `@tool` are automatically registered in the global registry
+        1. **Tool Registration**: Functions decorated with `@tool` are registered for explicit lookup, or added directly with `@tool(tool_manager=...)`
         2. **Schema Generation**: Tool decorators analyze function signatures and docstrings to create function calling schemas
         3. **LLM Integration**: Reasoning strategies receive tool schemas and can request specific tool calls
         4. **Argument Validation**: ToolManager validates LLM-provided arguments against function signatures with automatic type coercion
@@ -43,18 +50,34 @@ class ToolManager:
 
     instances: ClassVar[list["ToolManager"]] = []
 
-    def __init__(self, extra_tools: dict[str, Callable] | None = None):
-        # start from everything that was decorated
+    def __init__(
+        self,
+        tools: list[ToolRef] | tuple[ToolRef, ...] | None = None,
+        extra_tools: dict[str, Callable] | None = None,
+    ):
         ToolManager.instances.append(self)
-        self.tools = dict(_GLOBAL_TOOL_REGISTRY)
-        # allow per-agent overrides / reductions
+        self.tools: dict[str, Callable] = {}
+
+        if tools is not None:
+            self.register_many(tools)
+
         if extra_tools:
-            self.tools.update(extra_tools)
+            warnings.warn(
+                "`extra_tools` is deprecated; pass explicit `tools=` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self.register_many(tuple(extra_tools.values()))
 
     def register(self, fn: Callable):
         """Register a tool function by name"""
         name = fn.__name__
         self.tools[name] = fn  # storing the name & function pair as a dictionary
+
+    def register_many(self, tools: list[ToolRef] | tuple[ToolRef, ...]):
+        """Register explicit tool callables or registered tool names."""
+        for tool_ref in tools:
+            self.register(self._resolve_registration_tool_ref(tool_ref))
 
     @classmethod
     def add_tool_to_all(cls, fn: Callable):
@@ -62,36 +85,155 @@ class ToolManager:
         for instance in cls.instances:
             instance.register(fn)
 
-    def get_tool_schema(self, fn: Callable, schema_name: str) -> dict:
+    def _get_tool_schema(self, tool: ToolRef, schema_name: str | None = None) -> dict:
+        fn = self._resolve_configured_tool_ref(tool) if isinstance(tool, str) else tool
+        schema_name = schema_name or getattr(fn, "__name__", repr(fn))
         return getattr(fn, "__tool_schema__", None) or {
             "error": f"Tool {schema_name} missing __tool_schema__"
         }
 
-    def get_all_tools_schema(
-        self, selected_tools: list[str] | None = None
-    ) -> list[dict]:
-        """Return schemas for all tools or an explicit selection.
+    def get_tool_schema(self, fn: Callable, schema_name: str | None = None) -> dict:
+        """Deprecated compatibility alias for the private single-tool helper."""
+        warnings.warn(
+            "`get_tool_schema` is deprecated; use `get_tools_schema` for "
+            "configured or narrowed tool selections.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._get_tool_schema(fn, schema_name)
 
-        Omitting ``selected_tools`` or passing ``None`` uses the default
-        behavior of returning all registered tools.
-        ``selected_tools=[]`` returns no tools.
-        A non-empty list returns only the named tools in the given order.
+    def _unknown_tool_error(self, tool_name: str) -> ValueError:
+        return ValueError(
+            style(
+                "Unknown tool name(s): "
+                f"{[tool_name]}. Available tools: {sorted(self.tools)}",
+                color="red",
+            )
+        )
+
+    def _invalid_tool_ref_error(self, tool_ref: Any) -> TypeError:
+        return TypeError(
+            style(
+                "Tools must be callables or registered tool names, "
+                f"got {type(tool_ref).__name__}.",
+                color="red",
+            )
+        )
+
+    def _resolve_registration_tool_ref(self, tool_ref: ToolRef) -> Callable:
+        """Resolve constructor tool references.
+
+        Constructors may opt into globally registered bare ``@tool`` names.
+        Per-call selectors intentionally use the stricter configured-only
+        resolver below.
         """
-        if selected_tools is not None:
-            invalid_tools = [tool for tool in selected_tools if tool not in self.tools]
-            if invalid_tools:
-                available_tools = sorted(self.tools.keys())
-                raise ValueError(
-                    style(
-                        "Unknown tool name(s): "
-                        f"{invalid_tools}. Available tools: {available_tools}",
-                        color="red",
-                    )
+        if callable(tool_ref):
+            return tool_ref
+
+        if isinstance(tool_ref, str):
+            if tool_ref in self.tools:
+                return self.tools[tool_ref]
+            if tool_ref in _GLOBAL_TOOL_REGISTRY:
+                return _GLOBAL_TOOL_REGISTRY[tool_ref]
+            raise ValueError(
+                style(
+                    "Unknown tool name(s): "
+                    f"{[tool_ref]}. Available tools: "
+                    f"{sorted(set(self.tools) | set(_GLOBAL_TOOL_REGISTRY))}",
+                    color="red",
                 )
+            )
 
-            return [self.tools[tool].__tool_schema__ for tool in selected_tools]
+        raise self._invalid_tool_ref_error(tool_ref)
 
-        return [fn.__tool_schema__ for fn in self.tools.values()]
+    def _resolve_configured_tool_ref(self, tool_ref: ToolRef) -> Callable:
+        """Resolve per-call tool selectors against configured tools only."""
+        if isinstance(tool_ref, str):
+            if tool_ref in self.tools:
+                return self.tools[tool_ref]
+            raise self._unknown_tool_error(tool_ref)
+
+        if callable(tool_ref):
+            tool_name = getattr(tool_ref, "__name__", repr(tool_ref))
+            if tool_name in self.tools and self.tools[tool_name] is tool_ref:
+                return self.tools[tool_name]
+            raise self._unknown_tool_error(tool_name)
+
+        raise self._invalid_tool_ref_error(tool_ref)
+
+    def _normalize_tool_selection(self, tools: ToolSelection) -> list[ToolRef]:
+        """Normalize one or many explicit tool selectors to a list."""
+        if tools is None:
+            return []
+        if isinstance(tools, list | tuple):
+            return list(tools)
+        if isinstance(tools, str) or callable(tools):
+            return [tools]
+        raise self._invalid_tool_ref_error(tools)
+
+    def _resolve_tool_refs(self, tools: ToolSelection) -> list[Callable]:
+        return [
+            self._resolve_configured_tool_ref(tool_ref)
+            for tool_ref in self._normalize_tool_selection(tools)
+        ]
+
+    def _get_tool_execution_map(
+        self,
+        tools: ToolSelection | object = _UNSET,
+    ) -> dict[str, Callable]:
+        if tools is _UNSET:
+            return self.tools
+        if tools is None:
+            return {}
+        return {fn.__name__: fn for fn in self._resolve_tool_refs(tools)}
+
+    def get_tools_schema(
+        self,
+        tools: ToolSelection | object = _UNSET,
+        selected_tools: ToolSelection | object = _UNSET,
+    ) -> list[dict]:
+        """Return schemas for configured tools or an explicit per-call override.
+
+        Omitting ``tools`` returns the manager's configured tools.
+        Passing ``tools=None`` or ``tools=[]`` returns no tools.
+        Passing an explicit callable, name, or sequence returns exactly those
+        configured tools.
+        """
+        if selected_tools is not _UNSET:
+            warnings.warn(
+                "`selected_tools` is deprecated; use `tools=` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if tools is not _UNSET:
+                raise ValueError("Use either `tools` or `selected_tools`, not both.")
+            tools = selected_tools
+
+        if tools is _UNSET:
+            selected_fns = list(self.tools.values())
+        elif tools is None:
+            selected_fns = []
+        else:
+            selected_fns = self._resolve_tool_refs(tools)
+
+        return [self._get_tool_schema(fn) for fn in selected_fns]
+
+    def get_all_tools_schema(
+        self,
+        tools: ToolSelection | object = _UNSET,
+        selected_tools: ToolSelection | object = _UNSET,
+    ) -> list[dict]:
+        """Deprecated compatibility alias for ``get_tools_schema``."""
+        warnings.warn(
+            "`get_all_tools_schema` is deprecated; use `get_tools_schema` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if selected_tools is not _UNSET:
+            if tools is not _UNSET:
+                raise ValueError("Use either `tools` or `selected_tools`, not both.")
+            tools = selected_tools
+        return self.get_tools_schema(tools=tools)
 
     def call(self, name: str, arguments: dict) -> str:
         """Call a registered tool with validated args"""
@@ -103,7 +245,11 @@ class ToolManager:
         return name in self.tools
 
     async def _process_tool_call(
-        self, agent: "LLMAgent", tool_call: Any, index: int
+        self,
+        agent: "LLMAgent",
+        tool_call: Any,
+        index: int,
+        available_tools: dict[str, Callable],
     ) -> dict:
         """
         Internal helper to process a single tool call consistently.
@@ -118,7 +264,7 @@ class ToolManager:
 
         try:
             # Validate tool existence
-            if function_name not in self.tools:
+            if function_name not in available_tools:
                 raise ValueError(
                     style(
                         f"Function '{function_name}' not found in ToolManager",
@@ -134,7 +280,7 @@ class ToolManager:
                     style(f"Invalid JSON in function arguments: {e}", color="red")
                 ) from e
 
-            function_to_call = self.tools[function_name]
+            function_to_call = available_tools[function_name]
 
             # Inspect signature BEFORE calling
             sig = inspect.signature(function_to_call)
@@ -193,7 +339,12 @@ class ToolManager:
                 "response": f"Error: {e!s}",
             }
 
-    def call_tools(self, agent: "LLMAgent", llm_response: Any) -> list[dict]:
+    def call_tools(
+        self,
+        agent: "LLMAgent",
+        llm_response: Any,
+        tools: ToolSelection | object = _UNSET,
+    ) -> list[dict]:
         """
         Synchronous tool execution with safe async bridge.
         """
@@ -202,9 +353,12 @@ class ToolManager:
         if not tool_calls:
             return []
 
+        available_tools = self._get_tool_execution_map(tools)
+
         async def _run_all():
             tasks = [
-                self._process_tool_call(agent, tc, i) for i, tc in enumerate(tool_calls)
+                self._process_tool_call(agent, tc, i, available_tools)
+                for i, tc in enumerate(tool_calls)
             ]
             return await asyncio.gather(*tasks)
 
@@ -215,7 +369,12 @@ class ToolManager:
             with concurrent.futures.ThreadPoolExecutor() as executor:
                 return executor.submit(lambda: asyncio.run(_run_all())).result()
 
-    async def acall_tools(self, agent: "LLMAgent", llm_response: Any) -> list[dict]:
+    async def acall_tools(
+        self,
+        agent: "LLMAgent",
+        llm_response: Any,
+        tools: ToolSelection | object = _UNSET,
+    ) -> list[dict]:
         """
         Asynchronous tool execution (parallel via asyncio.gather).
         """
@@ -224,12 +383,11 @@ class ToolManager:
         if not tool_calls:
             return []
 
+        available_tools = self._get_tool_execution_map(tools)
+
         tasks = [
-            self._process_tool_call(agent, tc, i) for i, tc in enumerate(tool_calls)
+            self._process_tool_call(agent, tc, i, available_tools)
+            for i, tc in enumerate(tool_calls)
         ]
 
         return await asyncio.gather(*tasks)
-
-
-# Register callback to automatically add new tools to all ToolManager instances
-add_tool_callback(ToolManager.add_tool_to_all)

--- a/tests/test_integration/test_memory_reasoning.py
+++ b/tests/test_integration/test_memory_reasoning.py
@@ -38,7 +38,7 @@ def make_mock_agent(memory_instance, *, step_prompt="You are an agent in a simul
     agent.step_prompt = step_prompt
     agent.llm = Mock()
     agent.tool_manager = Mock()
-    agent.tool_manager.get_all_tools_schema.return_value = {}
+    agent.tool_manager.get_tools_schema.return_value = {}
     agent._step_display_data = {}
 
     # Wire memory
@@ -169,7 +169,7 @@ class TestCoTWithSTLTMemory:
         agent.step_prompt = "You are an agent"
         agent.llm = Mock()
         agent.tool_manager = Mock()
-        agent.tool_manager.get_all_tools_schema.return_value = {}
+        agent.tool_manager.get_tools_schema.return_value = {}
         agent._step_display_data = {}
 
         memory = STLTMemory(
@@ -244,7 +244,7 @@ class TestCoTWithEpisodicMemory:
         agent.step_prompt = "You are an agent"
         agent.llm = Mock()
         agent.tool_manager = Mock()
-        agent.tool_manager.get_all_tools_schema.return_value = {}
+        agent.tool_manager.get_tools_schema.return_value = {}
         agent._step_display_data = {}
 
         memory = EpisodicMemory(
@@ -328,7 +328,7 @@ class TestReActWithSTLTMemory:
         agent.step_prompt = "You are an agent"
         agent.llm = Mock()
         agent.tool_manager = Mock()
-        agent.tool_manager.get_all_tools_schema.return_value = {}
+        agent.tool_manager.get_tools_schema.return_value = {}
 
         memory = STLTMemory(
             agent=agent,
@@ -436,7 +436,7 @@ class TestReActWithEpisodicMemory:
         agent.step_prompt = "You are an agent"
         agent.llm = Mock()
         agent.tool_manager = Mock()
-        agent.tool_manager.get_all_tools_schema.return_value = {}
+        agent.tool_manager.get_tools_schema.return_value = {}
 
         memory = EpisodicMemory(
             agent=agent,
@@ -539,7 +539,7 @@ class TestReWOOWithSTLTMemory:
         agent.step_prompt = "You are an agent"
         agent.llm = Mock()
         agent.tool_manager = Mock()
-        agent.tool_manager.get_all_tools_schema.return_value = {}
+        agent.tool_manager.get_tools_schema.return_value = {}
         agent._step_display_data = {}
         default_obs = Observation(step=1, self_state={}, local_state={})
         agent.generate_obs = Mock(return_value=default_obs)
@@ -610,7 +610,7 @@ class TestReWOOWithEpisodicMemory:
         agent.step_prompt = "You are an agent"
         agent.llm = Mock()
         agent.tool_manager = Mock()
-        agent.tool_manager.get_all_tools_schema.return_value = {}
+        agent.tool_manager.get_tools_schema.return_value = {}
         agent._step_display_data = {}
         default_obs = Observation(step=1, self_state={}, local_state={})
         agent.generate_obs = Mock(return_value=default_obs)

--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import warnings
+from unittest.mock import Mock
 
 import pytest
 from mesa.agent import Agent
@@ -14,6 +15,8 @@ from mesa_llm import Plan
 from mesa_llm.llm_agent import LLMAgent
 from mesa_llm.memory.st_memory import ShortTermMemory
 from mesa_llm.reasoning.react import ReActReasoning
+from mesa_llm.tools.tool_decorator import tool
+from mesa_llm.tools.tool_manager import ToolManager
 
 
 def test_apply_plan_adds_to_memory(monkeypatch):
@@ -68,6 +71,98 @@ def test_apply_plan_adds_to_memory(monkeypatch):
     assert len(actions) == 1
     assert "tool_calls" in actions[0]
     assert actions[0]["tool_calls"][0] == {"tool": "foo", "argument": "bar"}
+
+
+def test_llm_agent_tools_constructor_tri_state():
+    class DummyModel(Model):
+        def __init__(self):
+            super().__init__(rng=42)
+
+    @tool
+    def agent_constructor_tool(agent, value: int) -> int:
+        """Agent constructor tool.
+        Args:
+            agent: The agent making the request (provided automatically)
+            value: Input.
+        Returns:
+            Output.
+        """
+        return value
+
+    model = DummyModel()
+
+    no_tools_agent = LLMAgent(model, reasoning=ReActReasoning, tools=None)
+    empty_tools_agent = LLMAgent(model, reasoning=ReActReasoning, tools=[])
+    explicit_tools_agent = LLMAgent(
+        model,
+        reasoning=ReActReasoning,
+        tools=[agent_constructor_tool],
+    )
+
+    assert no_tools_agent._tool_manager.tools == {}
+    assert empty_tools_agent._tool_manager.tools == {}
+    assert explicit_tools_agent._tool_manager.tools == {
+        "agent_constructor_tool": agent_constructor_tool
+    }
+
+
+def test_llm_agent_tool_manager_property_is_deprecated():
+    class DummyModel(Model):
+        def __init__(self):
+            super().__init__(rng=42)
+
+    agent = LLMAgent(DummyModel(), reasoning=ReActReasoning)
+    replacement = ToolManager()
+
+    with pytest.warns(DeprecationWarning, match="agent.tool_manager"):
+        assert agent.tool_manager is agent._tool_manager
+
+    with pytest.warns(DeprecationWarning, match="agent.tool_manager"):
+        agent.tool_manager = replacement
+
+    assert agent._tool_manager is replacement
+
+
+def test_apply_plan_executes_per_call_tool_selector():
+    class DummyModel(Model):
+        def __init__(self):
+            super().__init__(rng=42)
+
+    @tool
+    def override_apply_tool(agent, value: int) -> str:
+        """Override apply tool.
+        Args:
+            agent: The agent making the request (provided automatically)
+            value: Input.
+        Returns:
+            Output.
+        """
+        return f"{agent.unique_id}:{value}"
+
+    model = DummyModel()
+    agent = LLMAgent(model, reasoning=ReActReasoning, tools=[override_apply_tool])
+    agent.memory = Mock()
+
+    mock_tool_call = Mock()
+    mock_tool_call.id = "call_override"
+    mock_tool_call.function.name = "override_apply_tool"
+    mock_tool_call.function.arguments = '{"value": "7"}'
+
+    mock_message = Mock()
+    mock_message.tool_calls = [mock_tool_call]
+
+    plan = Plan(step=0, llm_plan=mock_message, tools=[override_apply_tool])
+
+    result = agent.apply_plan(plan)
+
+    assert result == [
+        {
+            "tool_call_id": "call_override",
+            "role": "tool",
+            "name": "override_apply_tool",
+            "response": f"{agent.unique_id}:7",
+        }
+    ]
 
 
 def test_apply_plan_preserves_multiple_tool_calls(monkeypatch):

--- a/tests/test_reasoning/test_cot.py
+++ b/tests/test_reasoning/test_cot.py
@@ -10,6 +10,8 @@ from mesa.space import MultiGrid
 from mesa_llm.llm_agent import LLMAgent
 from mesa_llm.reasoning.cot import CoTReasoning
 from mesa_llm.reasoning.reasoning import Observation, Plan
+from mesa_llm.tools.tool_decorator import tool
+from mesa_llm.tools.tool_manager import ToolManager
 
 
 class TestCoTReasoning:
@@ -120,7 +122,7 @@ class TestCoTReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
         mock_agent._step_display_data = {}
 
         mock_plan_response = llm_response_factory(
@@ -135,8 +137,8 @@ class TestCoTReasoning:
         calls = mock_agent.memory.add_to_memory.call_args_list
         assert not any(call.kwargs.get("type") == "observation" for call in calls)
 
-    def test_plan_with_selected_tools(self, llm_response_factory, mock_agent):
-        """Test plan method with selected tools."""
+    def test_plan_with_tools(self, llm_response_factory, mock_agent):
+        """Test plan method with explicit tools."""
         mock_agent.step_prompt = "You are an agent in a simulatio"
         mock_agent.memory = Mock()
         mock_agent.memory.format_long_term.return_value = "Long term memory"
@@ -144,7 +146,7 @@ class TestCoTReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
         mock_agent._step_display_data = {}  # Use real dict instead of Mock
         mock_plan_response = llm_response_factory(
             content="Thought 1: Test reasoning\nAction: test_action"
@@ -156,14 +158,83 @@ class TestCoTReasoning:
         reasoning = CoTReasoning(mock_agent)
 
         obs = Observation(step=1, self_state={}, local_state={})
-        selected_tools = ["tool1", "tool2"]
-        result = reasoning.plan(obs=obs, ttl=3, selected_tools=selected_tools)
+        tools = ["tool1", "tool2"]
+        result = reasoning.plan(obs=obs, ttl=3, tools=tools)
 
         assert isinstance(result, Plan)
         assert result.ttl == 3
-        # Check that tool schema was called with selected tools
-        assert mock_agent.tool_manager.get_all_tools_schema.call_count == 2
+        # Check that tool schema was called with explicit tools.
+        assert mock_agent.tool_manager.get_tools_schema.call_count == 2
+        mock_agent.tool_manager.get_tools_schema.assert_any_call(tools=tools)
         assert mock_agent.llm.generate.call_args_list[1].kwargs["tool_choice"] == "auto"
+
+    def test_plan_tools_sentinel_semantics(self, llm_response_factory, mock_agent):
+        """Omitted tools inherit; explicit per-call tools override."""
+
+        @tool
+        def inherited_cot_tool(agent, x: int) -> int:
+            """Inherited CoT tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                x: Input.
+            Returns:
+                Output.
+            """
+            return x
+
+        @tool
+        def override_cot_tool(agent, y: int) -> int:
+            """Override CoT tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                y: Input.
+            Returns:
+                Output.
+            """
+            return y
+
+        mock_agent.step_prompt = "You are an agent in a simulation"
+        mock_agent.memory = Mock()
+        mock_agent.memory.format_long_term.return_value = "Long term memory"
+        mock_agent.memory.format_short_term.return_value = "Short term memory"
+        mock_agent.memory.add_to_memory = Mock()
+        mock_agent.llm = Mock()
+        mock_agent._tool_manager = ToolManager(
+            tools=[inherited_cot_tool, override_cot_tool]
+        )
+        mock_agent._step_display_data = {}
+
+        reasoning = CoTReasoning(mock_agent)
+        obs = Observation(step=1, self_state={}, local_state={})
+
+        def schema_names_for_plan(**kwargs):
+            mock_plan_response = llm_response_factory(
+                content="Thought 1: Test reasoning\nAction: test_action"
+            )
+            mock_exec_response = llm_response_factory(content="executor response")
+            mock_agent.llm.generate.reset_mock()
+            mock_agent.llm.generate.side_effect = [
+                mock_plan_response,
+                mock_exec_response,
+            ]
+
+            reasoning.plan(obs=obs, **kwargs)
+
+            return [
+                [schema["function"]["name"] for schema in call.kwargs["tool_schema"]]
+                for call in mock_agent.llm.generate.call_args_list
+            ]
+
+        assert schema_names_for_plan() == [
+            ["inherited_cot_tool", "override_cot_tool"],
+            ["inherited_cot_tool", "override_cot_tool"],
+        ]
+        assert schema_names_for_plan(tools=None) == [[], []]
+        assert schema_names_for_plan(tools=[]) == [[], []]
+        assert schema_names_for_plan(tools=[override_cot_tool]) == [
+            ["override_cot_tool"],
+            ["override_cot_tool"],
+        ]
 
     def test_plan_with_custom_tool_calls(self, llm_response_factory, mock_agent):
         """Test plan method forwards a custom execution tool choice."""
@@ -174,7 +245,7 @@ class TestCoTReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
         mock_agent._step_display_data = {}
         mock_plan_response = llm_response_factory(
             content="Thought 1: Test reasoning\nAction: test_action"
@@ -214,7 +285,7 @@ class TestCoTReasoning:
         mock_agent.memory.aadd_to_memory = AsyncMock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
         mock_agent._step_display_data = {}
 
         mock_plan_response = llm_response_factory(
@@ -240,7 +311,7 @@ class TestCoTReasoning:
         mock_agent.memory.aadd_to_memory = AsyncMock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
         mock_agent._step_display_data = {}  # Use real dict instead of Mock
 
         mock_plan_response = llm_response_factory(
@@ -275,7 +346,7 @@ class TestCoTReasoning:
         mock_agent.memory.format_short_term.return_value = "Short term memory"
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
         mock_agent._step_display_data = {}
 
         mock_plan_response = llm_response_factory(

--- a/tests/test_reasoning/test_react.py
+++ b/tests/test_reasoning/test_react.py
@@ -100,7 +100,7 @@ class TestReActReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
 
         mock_agent.llm.generate.return_value = llm_response_factory(
             content=json.dumps(
@@ -119,13 +119,12 @@ class TestReActReasoning:
         assert result == mock_plan
         reasoning.execute_tool_call.assert_called_once_with(
             "custom_action",
-            selected_tools=None,
             ttl=1,
             tool_calls="auto",
         )
 
-    def test_plan_with_selected_tools(self, llm_response_factory, mock_agent):
-        """Test plan method with selected tools."""
+    def test_plan_with_tools(self, llm_response_factory, mock_agent):
+        """Test plan method with explicit tools."""
         mock_agent.step_prompt = "Default step prompt"
         mock_agent.memory = Mock()
         mock_agent.memory.get_prompt_ready.return_value = "memory1"
@@ -133,7 +132,7 @@ class TestReActReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
 
         mock_agent.llm.generate.return_value = llm_response_factory(
             content=json.dumps({"reasoning": "Test reasoning", "action": "test_action"})
@@ -145,14 +144,14 @@ class TestReActReasoning:
         reasoning.execute_tool_call = Mock(return_value=mock_plan)
 
         obs = Observation(step=1, self_state={}, local_state={})
-        selected_tools = ["tool1", "tool2"]
-        result = reasoning.plan(obs=obs, ttl=3, selected_tools=selected_tools)
+        tools = ["tool1", "tool2"]
+        result = reasoning.plan(obs=obs, ttl=3, tools=tools)
 
         assert result == mock_plan
-        mock_agent.tool_manager.get_all_tools_schema.assert_called_with(selected_tools)
+        mock_agent.tool_manager.get_tools_schema.assert_called_with(tools=tools)
         reasoning.execute_tool_call.assert_called_once_with(
             "test_action",
-            selected_tools=selected_tools,
+            tools=tools,
             ttl=3,
             tool_calls="auto",
         )
@@ -166,7 +165,7 @@ class TestReActReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
 
         mock_agent.llm.generate.return_value = llm_response_factory(
             content=json.dumps({"reasoning": "Test reasoning", "action": "test_action"})
@@ -182,7 +181,6 @@ class TestReActReasoning:
         assert result == mock_plan
         reasoning.execute_tool_call.assert_called_once_with(
             "test_action",
-            selected_tools=None,
             ttl=1,
             tool_calls="required",
         )
@@ -212,7 +210,7 @@ class TestReActReasoning:
         mock_agent.memory.aadd_to_memory = AsyncMock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
 
         mock_agent.llm.agenerate = AsyncMock(
             return_value=llm_response_factory(
@@ -236,7 +234,6 @@ class TestReActReasoning:
         mock_agent.llm.agenerate.assert_called_once()
         reasoning.aexecute_tool_call.assert_called_once_with(
             "async_action",
-            selected_tools=None,
             ttl=4,
             tool_calls="auto",
         )
@@ -265,7 +262,7 @@ class TestReActReasoning:
         mock_agent.memory.get_communication_history.return_value = ""
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
 
         mock_agent.llm.generate.return_value = llm_response_factory(
             content=json.dumps({"reasoning": "Test reasoning", "action": "test_action"})

--- a/tests/test_reasoning/test_reasoning.py
+++ b/tests/test_reasoning/test_reasoning.py
@@ -4,10 +4,13 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 
 from mesa_llm.reasoning.reasoning import (
+    _UNSET,
     Observation,
     Plan,
     Reasoning,
 )
+from mesa_llm.tools.tool_decorator import tool
+from mesa_llm.tools.tool_manager import ToolManager
 
 
 class TestObservation:
@@ -55,9 +58,7 @@ class TestReasoningBase:
         mock_agent.llm.generate.return_value = mock_llm_response
 
         # Mock the Tool Manager
-        mock_agent.tool_manager.get_all_tools_schema.return_value = [
-            {"schema": "example"}
-        ]
+        mock_agent.tool_manager.get_tools_schema.return_value = [{"schema": "example"}]
 
         # 2. Instantiate a concrete implementation of Reasoning to test the base method
         class ConcreteReasoning(Reasoning):
@@ -66,8 +67,9 @@ class TestReasoningBase:
                 prompt=None,
                 obs=None,
                 ttl=1,
-                selected_tools=None,
+                tools=_UNSET,
                 tool_calls="auto",
+                selected_tools=_UNSET,
             ):
                 pass  # Not needed for this test
 
@@ -75,9 +77,7 @@ class TestReasoningBase:
 
         # 3. Call the method we want to test
         chaining_message = "Execute the plan."
-        result_plan = reasoning.execute_tool_call(
-            chaining_message, selected_tools=["tool1"]
-        )
+        result_plan = reasoning.execute_tool_call(chaining_message, tools=["tool1"])
 
         # 4. Assert the results
         # Assert that the LLM was called with the correct parameters
@@ -88,8 +88,8 @@ class TestReasoningBase:
             system_prompt="You are an executor that executes the plan given to you in the prompt through tool calls. If the plan concludes that no action should be taken, do not call any tool.",
         )
         # Assert that the tool manager was asked for the correct schema
-        mock_agent.tool_manager.get_all_tools_schema.assert_called_once_with(
-            selected_tools=["tool1"]
+        mock_agent.tool_manager.get_tools_schema.assert_called_once_with(
+            tools=["tool1"]
         )
         # Assert that the output is a correctly formed Plan object
         assert isinstance(result_plan, Plan)
@@ -108,10 +108,18 @@ class TestReasoningBase:
         mock_agent.model.steps = 5
         mock_agent.llm.system_prompt = "base-system-prompt"
         mock_agent.llm.generate.return_value = llm_response_factory(content="ok")
-        mock_agent.tool_manager.get_all_tools_schema.return_value = []
+        mock_agent.tool_manager.get_tools_schema.return_value = []
 
         class ConcreteReasoning(Reasoning):
-            def plan(self, prompt=None, obs=None, ttl=1, selected_tools=None):
+            def plan(
+                self,
+                prompt=None,
+                obs=None,
+                ttl=1,
+                tools=_UNSET,
+                tool_calls="auto",
+                selected_tools=_UNSET,
+            ):
                 pass
 
         reasoning = ConcreteReasoning(agent=mock_agent)
@@ -130,10 +138,18 @@ class TestReasoningBase:
             return_value=llm_response_factory(content="ok")
         )
         mock_agent.memory.aadd_to_memory = AsyncMock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = []
+        mock_agent.tool_manager.get_tools_schema.return_value = []
 
         class ConcreteReasoning(Reasoning):
-            def plan(self, prompt=None, obs=None, ttl=1, selected_tools=None):
+            def plan(
+                self,
+                prompt=None,
+                obs=None,
+                ttl=1,
+                tools=_UNSET,
+                tool_calls="auto",
+                selected_tools=_UNSET,
+            ):
                 pass
 
         reasoning = ConcreteReasoning(agent=mock_agent)
@@ -149,7 +165,7 @@ class TestReasoningBase:
         mock_llm_response.choices = [Mock()]
         mock_llm_response.choices[0].message = "Final LLM message"
         mock_agent.llm.generate.return_value = mock_llm_response
-        mock_agent.tool_manager.get_all_tools_schema.return_value = []
+        mock_agent.tool_manager.get_tools_schema.return_value = []
 
         class ConcreteReasoning(Reasoning):
             def plan(
@@ -157,8 +173,9 @@ class TestReasoningBase:
                 prompt=None,
                 obs=None,
                 ttl=1,
-                selected_tools=None,
+                tools=_UNSET,
                 tool_calls="auto",
+                selected_tools=_UNSET,
             ):
                 pass
 
@@ -175,9 +192,7 @@ class TestReasoningBase:
         mock_agent.model.steps = 5
         mock_llm_response = llm_response_factory(content="Final LLM message")
         mock_agent.llm.generate.return_value = mock_llm_response
-        mock_agent.tool_manager.get_all_tools_schema.return_value = [
-            {"schema": "example"}
-        ]
+        mock_agent.tool_manager.get_tools_schema.return_value = [{"schema": "example"}]
 
         class ConcreteReasoning(Reasoning):
             def plan(
@@ -185,15 +200,16 @@ class TestReasoningBase:
                 prompt=None,
                 obs=None,
                 ttl=1,
-                selected_tools=None,
+                tools=_UNSET,
                 tool_calls="auto",
+                selected_tools=_UNSET,
             ):
                 pass
 
         reasoning = ConcreteReasoning(agent=mock_agent)
         reasoning.execute_tool_call(
             "Execute the plan.",
-            selected_tools=["tool1"],
+            tools=["tool1"],
             tool_calls="auto",
         )
 
@@ -204,6 +220,171 @@ class TestReasoningBase:
             system_prompt="You are an executor that executes the plan given to you in the prompt through tool calls. If the plan concludes that no action should be taken, do not call any tool.",
         )
 
+    def test_execute_tool_call_tools_sentinel_semantics(
+        self, llm_response_factory, mock_agent
+    ):
+        """Omitted tools inherit; explicit None/list overrides per call."""
+
+        @tool
+        def inherited_reasoning_tool(agent, x: int) -> int:
+            """Inherited reasoning tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                x: Input.
+            Returns:
+                Output.
+            """
+            return x
+
+        @tool
+        def override_reasoning_tool(agent, y: int) -> int:
+            """Override reasoning tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                y: Input.
+            Returns:
+                Output.
+            """
+            return y
+
+        mock_agent.model.steps = 5
+        mock_agent.llm.generate.return_value = llm_response_factory(content="ok")
+        mock_agent._tool_manager = ToolManager(
+            tools=[inherited_reasoning_tool, override_reasoning_tool]
+        )
+
+        class ConcreteReasoning(Reasoning):
+            def plan(
+                self,
+                prompt=None,
+                obs=None,
+                ttl=1,
+                tools=_UNSET,
+                tool_calls="auto",
+                selected_tools=_UNSET,
+            ):
+                pass
+
+        reasoning = ConcreteReasoning(agent=mock_agent)
+
+        reasoning.execute_tool_call("inherit")
+        schemas = mock_agent.llm.generate.call_args.kwargs["tool_schema"]
+        assert [schema["function"]["name"] for schema in schemas] == [
+            "inherited_reasoning_tool",
+            "override_reasoning_tool",
+        ]
+
+        reasoning.execute_tool_call("none", tools=None)
+        assert mock_agent.llm.generate.call_args.kwargs["tool_schema"] == []
+
+        reasoning.execute_tool_call("empty", tools=[])
+        assert mock_agent.llm.generate.call_args.kwargs["tool_schema"] == []
+
+        reasoning.execute_tool_call("override", tools=[override_reasoning_tool])
+        schemas = mock_agent.llm.generate.call_args.kwargs["tool_schema"]
+        assert [schema["function"]["name"] for schema in schemas] == [
+            "override_reasoning_tool"
+        ]
+
+    def test_execute_tool_call_selected_tools_alias_warns(
+        self, llm_response_factory, mock_agent
+    ):
+        """selected_tools remains a deprecated compatibility alias."""
+
+        @tool
+        def alias_reasoning_tool(agent, x: int) -> int:
+            """Alias reasoning tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                x: Input.
+            Returns:
+                Output.
+            """
+            return x
+
+        mock_agent.model.steps = 5
+        mock_agent.llm.generate.return_value = llm_response_factory(content="ok")
+        mock_agent._tool_manager = ToolManager(tools=[alias_reasoning_tool])
+
+        class ConcreteReasoning(Reasoning):
+            def plan(
+                self,
+                prompt=None,
+                obs=None,
+                ttl=1,
+                tools=_UNSET,
+                tool_calls="auto",
+                selected_tools=_UNSET,
+            ):
+                pass
+
+        reasoning = ConcreteReasoning(agent=mock_agent)
+
+        with pytest.warns(DeprecationWarning, match="selected_tools"):
+            reasoning.execute_tool_call(
+                "alias",
+                selected_tools=[alias_reasoning_tool],
+            )
+
+        schemas = mock_agent.llm.generate.call_args.kwargs["tool_schema"]
+        assert [schema["function"]["name"] for schema in schemas] == [
+            "alias_reasoning_tool"
+        ]
+
+    def test_execute_tool_call_rejects_unconfigured_per_call_tools(self, mock_agent):
+        """Per-call tools narrow configured tools and cannot inject tools."""
+
+        @tool
+        def configured_reasoning_tool(agent, x: int) -> int:
+            """Configured reasoning tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                x: Input.
+            Returns:
+                Output.
+            """
+            return x
+
+        @tool
+        def unconfigured_reasoning_tool(agent, y: int) -> int:
+            """Unconfigured reasoning tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                y: Input.
+            Returns:
+                Output.
+            """
+            return y
+
+        mock_agent._tool_manager = ToolManager(tools=[configured_reasoning_tool])
+        mock_agent.llm.generate.reset_mock()
+
+        class ConcreteReasoning(Reasoning):
+            def plan(
+                self,
+                prompt=None,
+                obs=None,
+                ttl=1,
+                tools=_UNSET,
+                tool_calls="auto",
+                selected_tools=_UNSET,
+            ):
+                pass
+
+        reasoning = ConcreteReasoning(agent=mock_agent)
+
+        with pytest.raises(ValueError, match="Unknown tool name"):
+            reasoning.execute_tool_call(
+                "reject callable", tools=[unconfigured_reasoning_tool]
+            )
+
+        with pytest.raises(ValueError, match="Unknown tool name"):
+            reasoning.execute_tool_call(
+                "reject name", tools=["unconfigured_reasoning_tool"]
+            )
+
+        mock_agent.llm.generate.assert_not_called()
+
     def test_aexecute_tool_call_records_plan_execution(
         self, llm_response_factory, mock_agent
     ):
@@ -211,9 +392,7 @@ class TestReasoningBase:
         mock_agent.model.steps = 5
         mock_llm_response = llm_response_factory(content="Async final LLM message")
         mock_agent.llm.agenerate = AsyncMock(return_value=mock_llm_response)
-        mock_agent.tool_manager.get_all_tools_schema.return_value = [
-            {"schema": "example"}
-        ]
+        mock_agent.tool_manager.get_tools_schema.return_value = [{"schema": "example"}]
         mock_agent.memory.aadd_to_memory = AsyncMock()
 
         class ConcreteReasoning(Reasoning):
@@ -222,14 +401,15 @@ class TestReasoningBase:
                 prompt=None,
                 obs=None,
                 ttl=1,
-                selected_tools=None,
+                tools=_UNSET,
                 tool_calls="auto",
+                selected_tools=_UNSET,
             ):
                 pass
 
         reasoning = ConcreteReasoning(agent=mock_agent)
         result_plan = asyncio.run(
-            reasoning.aexecute_tool_call("Execute the plan.", selected_tools=["tool1"])
+            reasoning.aexecute_tool_call("Execute the plan.", tools=["tool1"])
         )
 
         mock_agent.llm.agenerate.assert_awaited_once_with(

--- a/tests/test_reasoning/test_reasoning.py
+++ b/tests/test_reasoning/test_reasoning.py
@@ -331,6 +331,17 @@ class TestReasoningBase:
             "alias_reasoning_tool"
         ]
 
+        with pytest.warns(DeprecationWarning, match="selected_tools"):
+            reasoning.execute_tool_call(
+                "alias none inherits",
+                selected_tools=None,
+            )
+
+        schemas = mock_agent.llm.generate.call_args.kwargs["tool_schema"]
+        assert [schema["function"]["name"] for schema in schemas] == [
+            "alias_reasoning_tool"
+        ]
+
     def test_execute_tool_call_rejects_unconfigured_per_call_tools(self, mock_agent):
         """Per-call tools narrow configured tools and cannot inject tools."""
 

--- a/tests/test_reasoning/test_rewoo.py
+++ b/tests/test_reasoning/test_rewoo.py
@@ -110,7 +110,7 @@ class TestReWOOReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
 
         mock_plan_response = llm_response_factory(content="Test plan content")
         mock_exec_response = llm_response_factory(
@@ -139,7 +139,6 @@ class TestReWOOReasoning:
         assert reasoning.current_obs is not None
         reasoning.execute_tool_call.assert_called_once_with(
             "Test plan content",
-            selected_tools=None,
             ttl=4,
             tool_calls="auto",
         )
@@ -156,7 +155,7 @@ class TestReWOOReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
 
         mock_plan_response = llm_response_factory(content="Custom plan content")
         mock_exec_response = llm_response_factory(
@@ -188,7 +187,7 @@ class TestReWOOReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
 
         mock_plan_response = llm_response_factory(content="Test plan content")
         mock_exec_response = llm_response_factory(
@@ -206,13 +205,12 @@ class TestReWOOReasoning:
 
         reasoning.execute_tool_call.assert_called_once_with(
             "Test plan content",
-            selected_tools=None,
             ttl=1,
             tool_calls="required",
         )
 
-    def test_plan_with_selected_tools(self, llm_response_factory, mock_agent):
-        """Test plan method with selected tools."""
+    def test_plan_with_tools(self, llm_response_factory, mock_agent):
+        """Test plan method with explicit tools."""
         mock_agent.step_prompt = "Default step prompt"
         mock_agent.generate_obs.return_value = Observation(
             step=1, self_state={}, local_state={}
@@ -223,7 +221,7 @@ class TestReWOOReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
 
         mock_plan_response = llm_response_factory(content="Test plan content")
         mock_exec_response = llm_response_factory(
@@ -238,11 +236,11 @@ class TestReWOOReasoning:
             return_value=Plan(step=1, llm_plan=mock_exec_response.choices[0].message)
         )
 
-        selected_tools = ["tool1", "tool2"]
-        result = reasoning.plan(selected_tools=selected_tools)
+        tools = ["tool1", "tool2"]
+        result = reasoning.plan(tools=tools)
 
         assert isinstance(result, Plan)
-        mock_agent.tool_manager.get_all_tools_schema.assert_called_with(selected_tools)
+        mock_agent.tool_manager.get_tools_schema.assert_called_with(tools=tools)
 
     def test_plan_uses_scoped_system_prompt(self, llm_response_factory, mock_agent):
         """ReWOO plan should pass system prompt per call and not mutate llm state."""
@@ -253,7 +251,7 @@ class TestReWOOReasoning:
         mock_agent.memory.format_short_term.return_value = "Short term memory"
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
 
         mock_agent.llm.generate.return_value = llm_response_factory(
             content="Test plan content"
@@ -301,7 +299,7 @@ class TestReWOOReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
 
         mock_plan_response = llm_response_factory(content="Test plan content")
         mock_exec_response = llm_response_factory(content="Execution plan")
@@ -332,7 +330,7 @@ class TestReWOOReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
 
         mock_plan_response = llm_response_factory(content="Test plan content")
         mock_agent.llm.generate.return_value = mock_plan_response
@@ -388,7 +386,7 @@ class TestReWOOReasoning:
         mock_agent.memory.aadd_to_memory = AsyncMock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
 
         mock_plan_response = llm_response_factory(content="Async plan content")
         mock_exec_response = llm_response_factory(
@@ -423,7 +421,6 @@ class TestReWOOReasoning:
         assert reasoning.current_obs is not None
         reasoning.aexecute_tool_call.assert_called_once_with(
             "Async plan content",
-            selected_tools=None,
             ttl=7,
             tool_calls="auto",
         )
@@ -440,7 +437,7 @@ class TestReWOOReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
 
         mock_plan_response = Mock()
         mock_plan_response.choices = [Mock()]
@@ -481,7 +478,7 @@ class TestReWOOReasoning:
         mock_agent.memory.aadd_to_memory = AsyncMock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
 
         mock_plan_response = Mock()
         mock_plan_response.choices = [Mock()]
@@ -513,8 +510,8 @@ class TestReWOOReasoning:
         mock_agent.generate_obs.assert_not_called()
         mock_agent.agenerate_obs.assert_not_called()
 
-    def test_aplan_with_selected_tools(self, llm_response_factory, mock_agent):
-        """Test aplan method with selected tools."""
+    def test_aplan_with_tools(self, llm_response_factory, mock_agent):
+        """Test aplan method with explicit tools."""
         mock_agent.agenerate_obs = AsyncMock(
             return_value=Observation(step=1, self_state={}, local_state={})
         )
@@ -525,7 +522,7 @@ class TestReWOOReasoning:
         mock_agent.memory.aadd_to_memory = AsyncMock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
 
         mock_plan_response = llm_response_factory(content="Async plan content")
         mock_exec_response = llm_response_factory(
@@ -542,13 +539,11 @@ class TestReWOOReasoning:
             return_value=Plan(step=1, llm_plan=mock_exec_response.choices[0].message)
         )
 
-        selected_tools = ["tool1", "tool2"]
-        result = asyncio.run(
-            reasoning.aplan("test prompt", selected_tools=selected_tools)
-        )
+        tools = ["tool1", "tool2"]
+        result = asyncio.run(reasoning.aplan("test prompt", tools=tools))
 
         assert isinstance(result, Plan)
-        mock_agent.tool_manager.get_all_tools_schema.assert_called_with(selected_tools)
+        mock_agent.tool_manager.get_tools_schema.assert_called_with(tools=tools)
 
     def test_aplan_uses_scoped_system_prompt(self, llm_response_factory, mock_agent):
         """Async ReWOO plan should pass system prompt per call and not mutate llm state."""
@@ -560,7 +555,7 @@ class TestReWOOReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.memory.aadd_to_memory = AsyncMock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
 
         mock_agent.llm.agenerate = AsyncMock(
             return_value=llm_response_factory(content="Async plan content")
@@ -594,7 +589,7 @@ class TestReWOOReasoning:
         mock_agent.memory.aadd_to_memory = AsyncMock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
 
         mock_plan_response = llm_response_factory(content="Async plan content")
         mock_exec_response = llm_response_factory(content="Async execution plan")
@@ -626,7 +621,7 @@ class TestReWOOReasoning:
         mock_agent.memory.aadd_to_memory = AsyncMock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
 
         mock_plan_response = llm_response_factory(content="Async plan content")
         mock_agent.llm.agenerate = AsyncMock(return_value=mock_plan_response)
@@ -656,7 +651,7 @@ class TestReWOOReasoning:
         mock_agent.memory.aadd_to_memory = AsyncMock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
 
         mock_plan_response = Mock()
         mock_plan_response.choices = [Mock()]
@@ -734,7 +729,7 @@ class TestReWOOReasoning:
         mock_agent.memory.add_to_memory = Mock()
         mock_agent.llm = Mock()
         mock_agent.tool_manager = Mock()
-        mock_agent.tool_manager.get_all_tools_schema.return_value = {}
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
 
         mock_plan_response = llm_response_factory(content="Async plan content")
         mock_exec_response = llm_response_factory(

--- a/tests/test_reasoning/test_rewoo.py
+++ b/tests/test_reasoning/test_rewoo.py
@@ -242,6 +242,43 @@ class TestReWOOReasoning:
         assert isinstance(result, Plan)
         mock_agent.tool_manager.get_tools_schema.assert_called_with(tools=tools)
 
+    def test_plan_preserves_tools_for_remaining_tool_calls(
+        self, llm_response_factory, mock_agent
+    ):
+        """ReWOO continuation plans keep the original narrowed tool selection."""
+        mock_agent.step_prompt = "Default step prompt"
+        mock_agent.generate_obs.return_value = Observation(
+            step=1, self_state={}, local_state={}
+        )
+        mock_agent.memory = Mock()
+        mock_agent.memory.format_long_term.return_value = "Long term memory"
+        mock_agent.memory.format_short_term.return_value = "Short term memory"
+        mock_agent.memory.add_to_memory = Mock()
+        mock_agent.llm = Mock()
+        mock_agent.tool_manager = Mock()
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
+
+        mock_plan_response = llm_response_factory(content="Test plan content")
+        mock_exec_response = llm_response_factory(
+            content="Execution plan",
+            tool_calls=[_tool_call("call_1"), _tool_call("call_2")],
+        )
+        mock_agent.llm.generate.side_effect = [mock_plan_response, mock_exec_response]
+
+        reasoning = ReWOOReasoning(mock_agent)
+        reasoning.execute_tool_call = Mock(
+            return_value=Plan(step=1, llm_plan=mock_exec_response.choices[0].message)
+        )
+
+        tools = ["tool1"]
+        reasoning.plan(tools=tools)
+        continuation = reasoning.plan()
+
+        assert continuation.tools == tools
+        assert continuation.llm_plan.tool_calls == [
+            mock_exec_response.choices[0].message.tool_calls[0]
+        ]
+
     def test_plan_uses_scoped_system_prompt(self, llm_response_factory, mock_agent):
         """ReWOO plan should pass system prompt per call and not mutate llm state."""
         mock_agent.step_prompt = "Default step prompt"
@@ -544,6 +581,45 @@ class TestReWOOReasoning:
 
         assert isinstance(result, Plan)
         mock_agent.tool_manager.get_tools_schema.assert_called_with(tools=tools)
+
+    def test_aplan_preserves_tools_for_remaining_tool_calls(
+        self, llm_response_factory, mock_agent
+    ):
+        """Async ReWOO continuation plans keep the original narrowed tools."""
+        mock_agent.agenerate_obs = AsyncMock(
+            return_value=Observation(step=1, self_state={}, local_state={})
+        )
+        mock_agent.memory = Mock()
+        mock_agent.memory.format_long_term.return_value = "Long term memory"
+        mock_agent.memory.format_short_term.return_value = "Short term memory"
+        mock_agent.memory.add_to_memory = Mock()
+        mock_agent.memory.aadd_to_memory = AsyncMock()
+        mock_agent.llm = Mock()
+        mock_agent.tool_manager = Mock()
+        mock_agent.tool_manager.get_tools_schema.return_value = {}
+
+        mock_plan_response = llm_response_factory(content="Async plan content")
+        mock_exec_response = llm_response_factory(
+            content="Async execution plan",
+            tool_calls=[_tool_call("call_1"), _tool_call("call_2")],
+        )
+        mock_agent.llm.agenerate = AsyncMock(
+            side_effect=[mock_plan_response, mock_exec_response]
+        )
+
+        reasoning = ReWOOReasoning(mock_agent)
+        reasoning.aexecute_tool_call = AsyncMock(
+            return_value=Plan(step=1, llm_plan=mock_exec_response.choices[0].message)
+        )
+
+        tools = ["tool1"]
+        asyncio.run(reasoning.aplan("test prompt", tools=tools))
+        continuation = asyncio.run(reasoning.aplan("test prompt"))
+
+        assert continuation.tools == tools
+        assert continuation.llm_plan.tool_calls == [
+            mock_exec_response.choices[0].message.tool_calls[0]
+        ]
 
     def test_aplan_uses_scoped_system_prompt(self, llm_response_factory, mock_agent):
         """Async ReWOO plan should pass system prompt per call and not mutate llm state."""

--- a/tests/test_tools/test_tool_manager.py
+++ b/tests/test_tools/test_tool_manager.py
@@ -2,7 +2,22 @@ from unittest.mock import Mock
 
 import pytest
 
-from mesa_llm.tools.tool_decorator import _GLOBAL_TOOL_REGISTRY, tool
+from mesa_llm.tools.defaults import (
+    default_tools,
+    environment_tools,
+    external_tools,
+    legacy_tools,
+    math_tools,
+    social_query_tools,
+    spatial_tools,
+)
+from mesa_llm.tools.inbuilt_tools import move_one_step, speak_to, teleport_to_location
+from mesa_llm.tools.tool_decorator import (
+    _GLOBAL_TOOL_REGISTRY,
+    _TOOL_CALLBACKS,
+    add_tool_callback,
+    tool,
+)
 from mesa_llm.tools.tool_manager import ToolManager
 
 
@@ -11,12 +26,14 @@ class TestToolManager:
         """Set up test fixtures before each test method."""
         # Clear global registry to start fresh
         _GLOBAL_TOOL_REGISTRY.clear()
+        _TOOL_CALLBACKS.clear()
         # Clear instances list
         ToolManager.instances.clear()
 
     def teardown_method(self):
         """Clean up after each test method."""
         _GLOBAL_TOOL_REGISTRY.clear()
+        _TOOL_CALLBACKS.clear()
         ToolManager.instances.clear()
 
     def test_init_empty(self):
@@ -26,10 +43,36 @@ class TestToolManager:
         assert len(manager.tools) == 0
         assert manager in ToolManager.instances
 
-    def test_init_with_global_tools(self):
-        """Test initialization with global tools."""
+        none_manager = ToolManager(tools=None)
+        list_manager = ToolManager(tools=[])
+        assert none_manager.tools == {}
+        assert list_manager.tools == {}
 
-        # Register a tool globally first
+    def test_tool_set_factories(self):
+        """Tool-set factories are explicit immutable tuples."""
+        assert default_tools() == ()
+        assert legacy_tools() == (move_one_step, teleport_to_location, speak_to)
+        assert math_tools() == ()
+        assert spatial_tools() == ()
+        assert environment_tools() == ()
+        assert social_query_tools() == ()
+        assert external_tools() == ()
+        assert all(
+            isinstance(pack, tuple)
+            for pack in (
+                default_tools(),
+                math_tools(),
+                spatial_tools(),
+                environment_tools(),
+                social_query_tools(),
+                external_tools(),
+                legacy_tools(),
+            )
+        )
+
+    def test_init_does_not_copy_global_tools(self):
+        """Bare managers do not copy global tools implicitly."""
+
         @tool
         def test_global_tool(agent, param1: str) -> str:
             """Test global tool.
@@ -42,8 +85,96 @@ class TestToolManager:
             return param1
 
         manager = ToolManager()
-        assert "test_global_tool" in manager.tools
-        assert manager.tools["test_global_tool"] == test_global_tool
+        assert manager.tools == {}
+
+        explicit_manager = ToolManager(tools=["test_global_tool"])
+        assert explicit_manager.tools == {"test_global_tool": test_global_tool}
+
+    def test_init_with_explicit_callable_tools(self):
+        """Explicit callables configure exactly those tools."""
+
+        @tool
+        def tool_a(agent, x: int) -> int:
+            """Tool A.
+            Args:
+                agent: The agent making the request (provided automatically)
+                x: Input.
+            Returns:
+                Output.
+            """
+            return x
+
+        @tool
+        def tool_b(agent, y: int) -> int:
+            """Tool B.
+            Args:
+                agent: The agent making the request (provided automatically)
+                y: Input.
+            Returns:
+                Output.
+            """
+            return y
+
+        manager = ToolManager(tools=[tool_a])
+
+        assert manager.tools == {"tool_a": tool_a}
+        assert "tool_b" not in manager.tools
+
+    def test_late_bare_tool_does_not_leak_into_explicit_managers(self):
+        """Bare @tool registrations after construction do not mutate managers."""
+        no_tool_manager = ToolManager()
+
+        @tool
+        def initial_tool(agent, x: int) -> int:
+            """Initial tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                x: Input.
+            Returns:
+                Output.
+            """
+            return x
+
+        explicit_manager = ToolManager(tools=[initial_tool])
+
+        @tool
+        def late_tool(agent, y: int) -> int:
+            """Late tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                y: Input.
+            Returns:
+                Output.
+            """
+            return y
+
+        assert no_tool_manager.tools == {}
+        assert explicit_manager.tools == {"initial_tool": initial_tool}
+        assert "late_tool" not in explicit_manager.tools
+
+    def test_late_bare_tool_does_not_leak_through_deprecated_callbacks(self):
+        """Deprecated global callbacks cannot opt managers into bare tools."""
+        manager = ToolManager()
+
+        def add_to_all_callback(fn):
+            ToolManager.add_tool_to_all(fn)
+
+        with pytest.warns(DeprecationWarning, match="add_tool_callback"):
+            add_tool_callback(add_to_all_callback)
+
+        @tool
+        def callback_tool(agent, x: int) -> int:
+            """Callback tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                x: Input.
+            Returns:
+                Output.
+            """
+            return x
+
+        assert manager.tools == {}
+        assert callback_tool is _GLOBAL_TOOL_REGISTRY["callback_tool"]
 
     def test_init_with_extra_tools(self):
         """Test initialization with extra tools."""
@@ -115,8 +246,8 @@ class TestToolManager:
         assert "shared_tool" in manager1.tools
         assert "shared_tool" in manager2.tools
 
-    def test_get_tool_schema(self):
-        """Test getting tool schema."""
+    def test_get_tool_schema_deprecated_alias(self):
+        """Deprecated single-tool schema alias still works."""
         manager = ToolManager()
 
         @tool
@@ -131,23 +262,35 @@ class TestToolManager:
             return param
 
         manager.register(schema_test_tool)
-        schema = manager.get_tool_schema(schema_test_tool, "schema_test_tool")
+        with pytest.warns(DeprecationWarning, match="get_tool_schema"):
+            schema = manager.get_tool_schema(schema_test_tool)
 
         assert "type" in schema
         assert "function" in schema
         assert schema["function"]["name"] == "schema_test_tool"
 
-    def test_get_tool_schema_missing(self):
-        """Test getting schema for tool without schema."""
+    def test_get_tool_schema_deprecated_alias_missing(self):
+        """Deprecated single-tool schema alias handles missing schema."""
         manager = ToolManager()
 
         def no_schema_tool():
             return "test"
 
-        schema = manager.get_tool_schema(no_schema_tool, "no_schema_tool")
+        with pytest.warns(DeprecationWarning, match="get_tool_schema"):
+            schema = manager.get_tool_schema(no_schema_tool, "no_schema_tool")
         assert "error" in schema
 
-    def test_get_all_tools_schema(self):
+    def test_private_get_tool_schema_missing(self):
+        """Private single-tool helper handles missing schema."""
+        manager = ToolManager()
+
+        def no_schema_tool():
+            return "test"
+
+        schema = manager._get_tool_schema(no_schema_tool)
+        assert "error" in schema
+
+    def test_get_tools_schema(self):
         """Test getting all tools schemas."""
 
         @tool
@@ -172,13 +315,34 @@ class TestToolManager:
             """
             return y
 
-        manager = ToolManager()
-        schemas = manager.get_all_tools_schema()
+        manager = ToolManager(tools=[tool1, tool2])
+        schemas = manager.get_tools_schema()
 
         assert len(schemas) == 2
         assert all("function" in schema for schema in schemas)
 
-    def test_get_all_tools_schema_with_selected_tools(self):
+    def test_get_all_tools_schema_deprecated_alias(self):
+        """Deprecated all-tools schema alias delegates to get_tools_schema."""
+
+        @tool
+        def alias_tool(agent, x: int) -> int:
+            """Alias tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                x: Input.
+            Returns:
+                Output.
+            """
+            return x
+
+        manager = ToolManager(tools=[alias_tool])
+        with pytest.warns(DeprecationWarning, match="get_all_tools_schema"):
+            schemas = manager.get_all_tools_schema()
+
+        assert len(schemas) == 1
+        assert schemas[0]["function"]["name"] == "alias_tool"
+
+    def test_get_tools_schema_with_selected_tools(self):
         """Test getting schemas for selected tools only."""
 
         @tool
@@ -214,11 +378,11 @@ class TestToolManager:
             """
             return z
 
-        manager = ToolManager()
+        manager = ToolManager(tools=[tool_a, tool_b, tool_c])
 
         # Test selecting specific tools
         selected_tools = ["tool_a", "tool_c"]
-        schemas = manager.get_all_tools_schema(selected_tools)
+        schemas = manager.get_tools_schema(tools=selected_tools)
 
         assert len(schemas) == 2
         tool_names = [schema["function"]["name"] for schema in schemas]
@@ -226,7 +390,7 @@ class TestToolManager:
         assert "tool_c" in tool_names
         assert "tool_b" not in tool_names
 
-    def test_get_all_tools_schema_empty_list(self):
+    def test_get_tools_schema_empty_list(self):
         """Test that empty list returns no tools (selected_tools=[] means 'no tools')."""
 
         @tool
@@ -243,12 +407,12 @@ class TestToolManager:
         manager = ToolManager()
 
         # Empty list should return no tools — the user explicitly asked for none
-        empty_list_schemas = manager.get_all_tools_schema([])
+        empty_list_schemas = manager.get_tools_schema(tools=[])
 
         assert len(empty_list_schemas) == 0
 
-    def test_get_all_tools_schema_none(self):
-        """Test that None returns all tools."""
+    def test_get_tools_schema_none(self):
+        """Test that explicit None returns no tools."""
 
         @tool
         def test_tool(agent, x: int) -> int:
@@ -261,14 +425,15 @@ class TestToolManager:
             """
             return x
 
-        manager = ToolManager()
+        manager = ToolManager(tools=[test_tool])
 
-        all_schemas = manager.get_all_tools_schema()
-        none_schemas = manager.get_all_tools_schema(None)
+        all_schemas = manager.get_tools_schema()
+        none_schemas = manager.get_tools_schema(tools=None)
 
-        assert len(none_schemas) == len(all_schemas)
+        assert len(all_schemas) == 1
+        assert none_schemas == []
 
-    def test_get_all_tools_schema_nonexistent_tools(self):
+    def test_get_tools_schema_nonexistent_tools(self):
         """Test that requesting nonexistent tools raises appropriate errors."""
 
         @tool
@@ -288,10 +453,10 @@ class TestToolManager:
         selected_tools = ["existing_tool", "nonexistent_tool"]
 
         with pytest.raises(ValueError, match="Unknown tool name"):
-            manager.get_all_tools_schema(selected_tools)
+            manager.get_tools_schema(tools=selected_tools)
 
-    def test_get_all_tools_schema_single_tool(self):
-        """Test selecting a single tool."""
+    def test_get_tools_schema_single_tool_sequence(self):
+        """Test selecting a single tool in a sequence."""
 
         @tool
         def single_tool(agent, x: int) -> int:
@@ -315,12 +480,142 @@ class TestToolManager:
             """
             return y
 
-        manager = ToolManager()
+        manager = ToolManager(tools=[single_tool])
 
-        schemas = manager.get_all_tools_schema(["single_tool"])
+        schemas = manager.get_tools_schema(tools=["single_tool"])
 
         assert len(schemas) == 1
         assert schemas[0]["function"]["name"] == "single_tool"
+
+    def test_get_tools_schema_single_string_selector(self):
+        """A single configured tool name narrows the schema selection."""
+
+        @tool
+        def single_name_tool(agent, x: int) -> int:
+            """Single name tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                x: Input.
+            Returns:
+                Output.
+            """
+            return x
+
+        @tool
+        def other_name_tool(agent, y: str) -> str:
+            """Other name tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                y: Input.
+            Returns:
+                Output.
+            """
+            return y
+
+        manager = ToolManager(tools=[single_name_tool, other_name_tool])
+
+        schemas = manager.get_tools_schema(tools="single_name_tool")
+
+        assert len(schemas) == 1
+        assert schemas[0]["function"]["name"] == "single_name_tool"
+
+    def test_get_tools_schema_single_callable_selector(self):
+        """A single configured callable narrows the schema selection."""
+
+        @tool
+        def single_callable_tool(agent, x: int) -> int:
+            """Single callable tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                x: Input.
+            Returns:
+                Output.
+            """
+            return x
+
+        @tool
+        def other_callable_tool(agent, y: str) -> str:
+            """Other callable tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                y: Input.
+            Returns:
+                Output.
+            """
+            return y
+
+        manager = ToolManager(tools=[single_callable_tool, other_callable_tool])
+
+        schemas = manager.get_tools_schema(tools=single_callable_tool)
+
+        assert len(schemas) == 1
+        assert schemas[0]["function"]["name"] == "single_callable_tool"
+
+    def test_get_tools_schema_rejects_unconfigured_callable(self):
+        """Per-call callable selectors cannot add unconfigured tools."""
+
+        @tool
+        def configured_tool(agent, x: int) -> int:
+            """Configured tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                x: Input.
+            Returns:
+                Output.
+            """
+            return x
+
+        @tool
+        def unconfigured_tool(agent, y: int) -> int:
+            """Unconfigured tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                y: Input.
+            Returns:
+                Output.
+            """
+            return y
+
+        manager = ToolManager(tools=[configured_tool])
+
+        with pytest.raises(ValueError, match="Unknown tool name"):
+            manager.get_tools_schema(tools=[unconfigured_tool])
+
+        with pytest.raises(ValueError, match="Unknown tool name"):
+            manager.get_tools_schema(tools=unconfigured_tool)
+
+    def test_get_tools_schema_rejects_unconfigured_registered_name(self):
+        """Per-call string selectors only narrow configured tools."""
+
+        @tool
+        def configured_name_tool(agent, x: int) -> int:
+            """Configured name tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                x: Input.
+            Returns:
+                Output.
+            """
+            return x
+
+        @tool
+        def unconfigured_name_tool(agent, y: int) -> int:
+            """Unconfigured name tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                y: Input.
+            Returns:
+                Output.
+            """
+            return y
+
+        manager = ToolManager(tools=[configured_name_tool])
+
+        with pytest.raises(ValueError, match="Unknown tool name"):
+            manager.get_tools_schema(tools=["unconfigured_name_tool"])
+
+        with pytest.raises(ValueError, match="Unknown tool name"):
+            manager.get_tools_schema(tools="unconfigured_name_tool")
 
     def test_call_tool_success(self):
         """Test successfully calling a tool."""
@@ -383,7 +678,6 @@ class TestToolManager:
 
     def test_call_tools_success(self):
         """Test successful tool calling."""
-        manager = ToolManager()
 
         @tool
         def test_tool(agent, param1: str) -> str:
@@ -395,6 +689,8 @@ class TestToolManager:
                 Processed parameter.
             """
             return f"Processed: {param1}"
+
+        manager = ToolManager(tools=[test_tool])
 
         # Mock agent
         mock_agent = Mock()
@@ -415,6 +711,102 @@ class TestToolManager:
         assert result[0]["role"] == "tool"
         assert result[0]["name"] == "test_tool"
         assert "Processed: test_value" in result[0]["response"]
+
+    def test_call_tools_single_selectors(self):
+        """Execution accepts a single configured callable or name selector."""
+
+        @tool
+        def configured_execution_tool(agent, value: int) -> int:
+            """Configured execution tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                value: Input.
+            Returns:
+                Output.
+            """
+            return value + 1
+
+        manager = ToolManager(tools=[configured_execution_tool])
+        mock_agent = Mock()
+
+        mock_tool_call = Mock()
+        mock_tool_call.id = "call_single_selector"
+        mock_tool_call.function.name = "configured_execution_tool"
+        mock_tool_call.function.arguments = '{"value": 3}'
+
+        mock_response = Mock()
+        mock_response.tool_calls = [mock_tool_call]
+
+        name_result = manager.call_tools(
+            mock_agent,
+            mock_response,
+            tools="configured_execution_tool",
+        )
+        callable_result = manager.call_tools(
+            mock_agent,
+            mock_response,
+            tools=configured_execution_tool,
+        )
+
+        assert name_result[0]["response"] == "4"
+        assert callable_result[0]["response"] == "4"
+
+    def test_call_tools_rejects_unconfigured_per_call_callable(self):
+        """Execution selectors cannot add tools outside the configured set."""
+
+        @tool
+        def configured_execution_tool(agent, value: int) -> int:
+            """Configured execution tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                value: Input.
+            Returns:
+                Output.
+            """
+            return value
+
+        @tool
+        def unconfigured_execution_tool(agent, value: int) -> int:
+            """Unconfigured execution tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                value: Input.
+            Returns:
+                Output.
+            """
+            return value
+
+        manager = ToolManager(tools=[configured_execution_tool])
+        mock_agent = Mock()
+
+        mock_tool_call = Mock()
+        mock_tool_call.id = "call_unconfigured"
+        mock_tool_call.function.name = "unconfigured_execution_tool"
+        mock_tool_call.function.arguments = '{"value": 3}'
+
+        mock_response = Mock()
+        mock_response.tool_calls = [mock_tool_call]
+
+        with pytest.raises(ValueError, match="Unknown tool name"):
+            manager.call_tools(
+                mock_agent,
+                mock_response,
+                tools=[unconfigured_execution_tool],
+            )
+
+        with pytest.raises(ValueError, match="Unknown tool name"):
+            manager.call_tools(
+                mock_agent,
+                mock_response,
+                tools=unconfigured_execution_tool,
+            )
+
+        with pytest.raises(ValueError, match="Unknown tool name"):
+            manager.call_tools(
+                mock_agent,
+                mock_response,
+                tools="unconfigured_execution_tool",
+            )
 
     def test_call_tools_function_not_found(self):
         """Test call_tools with non-existent function."""
@@ -437,7 +829,6 @@ class TestToolManager:
 
     def test_call_tools_invalid_json(self):
         """Test call_tools with invalid JSON arguments."""
-        manager = ToolManager()
 
         @tool
         def test_tool(agent, param1: str) -> str:
@@ -450,6 +841,7 @@ class TestToolManager:
             """
             return f"Processed: {param1}"
 
+        manager = ToolManager(tools=[test_tool])
         mock_agent = Mock()
 
         mock_tool_call = Mock()
@@ -503,7 +895,6 @@ class TestToolManager:
 
     def test_call_tools_type_coercion_float(self):
         """Test coercion of float arguments passed as JSON strings."""
-        manager = ToolManager()
 
         @tool
         def float_tool(agent, amount: float) -> str:
@@ -516,6 +907,7 @@ class TestToolManager:
             """
             return f"{amount:.2f}"
 
+        manager = ToolManager(tools=[float_tool])
         mock_agent = Mock()
 
         mock_tool_call = Mock()
@@ -534,7 +926,6 @@ class TestToolManager:
 
     def test_call_tools_type_coercion_float_with_string_annotation(self):
         """Test coercion when annotations are stored as strings."""
-        manager = ToolManager()
 
         @tool
         def float_tool(agent, amount: "float") -> "str":
@@ -547,6 +938,7 @@ class TestToolManager:
             """
             return f"{amount:.2f}"
 
+        manager = ToolManager(tools=[float_tool])
         mock_agent = Mock()
 
         mock_tool_call = Mock()
@@ -565,7 +957,6 @@ class TestToolManager:
 
     def test_call_tools_type_coercion_int(self):
         """Test coercion of int arguments passed as JSON strings."""
-        manager = ToolManager()
 
         @tool
         def int_tool(agent, count: int) -> int:
@@ -578,6 +969,7 @@ class TestToolManager:
             """
             return count + 1
 
+        manager = ToolManager(tools=[int_tool])
         mock_agent = Mock()
 
         mock_tool_call = Mock()
@@ -596,7 +988,6 @@ class TestToolManager:
 
     def test_call_tools_no_response(self):
         """Test call_tools when tool returns None."""
-        manager = ToolManager()
 
         @tool
         def silent_tool(agent) -> None:
@@ -608,6 +999,7 @@ class TestToolManager:
             """
             return None
 
+        manager = ToolManager(tools=[silent_tool])
         mock_agent = Mock()
 
         mock_tool_call = Mock()
@@ -673,13 +1065,15 @@ class TestToolManager:
             """
             return z
 
-        manager = ToolManager()
+        manager = ToolManager(
+            tools=[consistency_tool_a, consistency_tool_b, consistency_tool_c]
+        )
 
         # Test that same selected_tools always returns same schemas
         selected_tools = ["consistency_tool_a", "consistency_tool_c"]
 
-        schemas1 = manager.get_all_tools_schema(selected_tools)
-        schemas2 = manager.get_all_tools_schema(selected_tools)
+        schemas1 = manager.get_tools_schema(tools=selected_tools)
+        schemas2 = manager.get_tools_schema(tools=selected_tools)
 
         names1 = sorted([schema["function"]["name"] for schema in schemas1])
         names2 = sorted([schema["function"]["name"] for schema in schemas2])
@@ -689,7 +1083,7 @@ class TestToolManager:
 
         # Test order independence
         reversed_tools = list(reversed(selected_tools))
-        schemas3 = manager.get_all_tools_schema(reversed_tools)
+        schemas3 = manager.get_tools_schema(tools=reversed_tools)
         names3 = sorted([schema["function"]["name"] for schema in schemas3])
 
         assert names1 == names3
@@ -708,11 +1102,11 @@ class TestToolManager:
             """
             return x
 
-        manager = ToolManager()
+        manager = ToolManager(tools=[duplicate_test_tool])
 
         # Test with duplicate tool names
         selected_tools = ["duplicate_test_tool", "duplicate_test_tool"]
-        schemas = manager.get_all_tools_schema(selected_tools)
+        schemas = manager.get_tools_schema(tools=selected_tools)
 
         # Should return schemas for each request (may include duplicates)
         assert len(schemas) == 2
@@ -742,19 +1136,21 @@ class TestToolManager:
             """
             return y
 
-        manager1 = ToolManager()
-        manager2 = ToolManager()
+        manager1 = ToolManager(tools=[shared_tool_1])
+        manager2 = ToolManager(tools=[shared_tool_1, shared_tool_2])
 
-        # Both managers should have the same tools
-        all_schemas_1 = manager1.get_all_tools_schema()
-        all_schemas_2 = manager2.get_all_tools_schema()
+        # Bare managers no longer copy global registrations; explicit managers
+        # expose only their configured maximum capability sets.
+        all_schemas_1 = manager1.get_tools_schema()
+        all_schemas_2 = manager2.get_tools_schema()
 
-        assert len(all_schemas_1) == len(all_schemas_2)
+        assert len(all_schemas_1) == 1
+        assert len(all_schemas_2) == 2
 
         # Selected tools should work the same on both managers
         selected_tools = ["shared_tool_1"]
-        schemas_1 = manager1.get_all_tools_schema(selected_tools)
-        schemas_2 = manager2.get_all_tools_schema(selected_tools)
+        schemas_1 = manager1.get_tools_schema(tools=selected_tools)
+        schemas_2 = manager2.get_tools_schema(tools=selected_tools)
 
         assert len(schemas_1) == len(schemas_2) == 1
         assert schemas_1[0]["function"]["name"] == schemas_2[0]["function"]["name"]
@@ -778,7 +1174,6 @@ class TestToolManager:
         - The asynchronous execution path using `asyncio.gather`
         returns the correct results.
         """
-        manager = ToolManager()
         mock_agent = Mock()
 
         @tool
@@ -793,6 +1188,8 @@ class TestToolManager:
                 Processed value.
             """
             return f"Async: {value}"
+
+        manager = ToolManager(tools=[async_test_tool])
 
         mock_tool_call = Mock()
         mock_tool_call.id = "call_async"

--- a/tests/test_tools/test_tool_manager.py
+++ b/tests/test_tools/test_tool_manager.py
@@ -204,9 +204,30 @@ class TestToolManager:
             },
         }
 
-        extra_tools = {"extra_tool": extra_tool}
-        manager = ToolManager(extra_tools=extra_tools)
-        assert "extra_tool" in manager.tools
+        extra_tools = {"alias_name": extra_tool}
+        with pytest.warns(DeprecationWarning, match="extra_tools"):
+            manager = ToolManager(extra_tools=extra_tools)
+
+        assert "alias_name" in manager.tools
+        assert "extra_tool" not in manager.tools
+
+        schemas = manager.get_tools_schema()
+        selected_schemas = manager.get_tools_schema(tools="alias_name")
+        callable_schemas = manager.get_tools_schema(tools=extra_tool)
+        assert schemas[0]["function"]["name"] == "alias_name"
+        assert selected_schemas[0]["function"]["name"] == "alias_name"
+        assert callable_schemas[0]["function"]["name"] == "alias_name"
+
+        mock_tool_call = Mock()
+        mock_tool_call.id = "call_alias"
+        mock_tool_call.function.name = "alias_name"
+        mock_tool_call.function.arguments = '{"x": 4}'
+        mock_response = Mock()
+        mock_response.tool_calls = [mock_tool_call]
+
+        result = manager.call_tools(Mock(), mock_response, tools="alias_name")
+        assert result[0]["name"] == "alias_name"
+        assert result[0]["response"] == "4"
 
     def test_register_tool(self):
         """Test registering a tool manually."""
@@ -341,6 +362,41 @@ class TestToolManager:
 
         assert len(schemas) == 1
         assert schemas[0]["function"]["name"] == "alias_tool"
+
+    def test_deprecated_schema_aliases_none_inherits_configured_tools(self):
+        """Deprecated None selectors keep old all-configured semantics."""
+
+        @tool
+        def compatibility_tool(agent, x: int) -> int:
+            """Compatibility tool.
+            Args:
+                agent: The agent making the request (provided automatically)
+                x: Input.
+            Returns:
+                Output.
+            """
+            return x
+
+        manager = ToolManager(tools=[compatibility_tool])
+
+        assert manager.get_tools_schema(tools=None) == []
+
+        with pytest.warns(DeprecationWarning, match="get_all_tools_schema"):
+            positional_none_schemas = manager.get_all_tools_schema(None)
+
+        with pytest.warns(DeprecationWarning, match="get_all_tools_schema"):
+            selected_none_schemas = manager.get_all_tools_schema(selected_tools=None)
+
+        with pytest.warns(DeprecationWarning, match="selected_tools"):
+            selected_alias_schemas = manager.get_tools_schema(selected_tools=None)
+
+        for schemas in (
+            positional_none_schemas,
+            selected_none_schemas,
+            selected_alias_schemas,
+        ):
+            assert len(schemas) == 1
+            assert schemas[0]["function"]["name"] == "compatibility_tool"
 
     def test_get_tools_schema_with_selected_tools(self):
         """Test getting schemas for selected tools only."""


### PR DESCRIPTION
Partly addresses https://github.com/mesa/mesa-llm/issues/148

### Summary

This PR makes LLM tool exposure explicit and configurable. `LLMAgent(..., tools=None)` and bare `ToolManager()` now expose no tools by default, while simulations can opt in with explicit tool callables, registered tool names, or helper functions such as `legacy_tools()`.

### Motive

Mesa-LLM previously exposed globally registered tools implicitly. That made it easy for agents to receive tools unintentionally, including state-changing tools, and made per-call tool selection harder to reason about.

This PR tightens the tool API so agent capabilities are configured explicitly and per-call `tools=` selections can only narrow the agent’s configured capabilities.

This is part of a broader tools vs. actions refactor, but this PR intentionally does not introduce an action API or move existing mutating tools yet.

### Implementation

- Added explicit `tools=` configuration to `LLMAgent`.
- Changed bare `ToolManager()` / `ToolManager(tools=None)` / `ToolManager(tools=[])` to expose no tools.
- Made the agent tool manager internal as `_tool_manager`, with `agent.tool_manager` retained as a deprecated compatibility property.
- Added tool helper functions in `mesa_llm.tools.defaults`, including `default_tools()` and `legacy_tools()`.
- Added `ToolManager.get_tools_schema(...)` as the forward schema API.
- Kept `get_all_tools_schema(...)` and `get_tool_schema(...)` as deprecated compatibility aliases.
- Updated reasoning APIs to accept `tools=`, while keeping `selected_tools` as a deprecated compatibility alias.
- Ensured per-call `tools=` selections can only narrow configured tools and fail fast for unknown or unconfigured tools.
- Prevented late bare `@tool` registration from leaking into no-tool or explicitly configured managers.
- Updated docs and examples to use constructor-level `tools=` configuration instead of constructing or assigning public tool managers directly.

### Usage Examples

```python
from mesa_llm import LLMAgent, legacy_tools
from mesa_llm.reasoning.cot import CoTReasoning

agent = LLMAgent(
    model=model,
    reasoning=CoTReasoning,
    tools=legacy_tools(),
)

plan = agent.reasoning.plan(prompt="Inspect the local state")

plan_without_tools = agent.reasoning.plan(
    prompt="Reason without tools for this call",
    tools=None,
)

plan_with_one_tool = agent.reasoning.plan(
    prompt="Use only this configured helper",
    tools="speak_to",
)
