### PR TITLE
feat(memory): add embedding-based relevance scoring to EpisodicMemory

### DIFF
--- a/docs/apis/memory.md
+++ b/docs/apis/memory.md
@@ -23,6 +23,31 @@ class MyAgent(LLMAgent):
       )
 ```
 
+### Episodic memory with relevance scoring
+
+`EpisodicMemory` retrieves the most useful memories by combining **importance**,
+**recency**, and—when an `embedding_model` is configured—**relevance** (the
+cosine similarity between a focal query and each memory's embedding), following
+the Generative Agents retrieval design. Without an `embedding_model` the
+relevance term is skipped and retrieval falls back to importance + recency.
+
+```python
+from mesa_llm.memory.episodic_memory import EpisodicMemory
+
+self.memory = EpisodicMemory(
+      agent=self,
+      llm_model="openai/gpt-4o-mini",          # used to grade event importance
+      embedding_model="openai/text-embedding-3-small",  # enables relevance
+      relevance_weight=1.0,                     # weight of the relevance term
+      importance_weight=1.0,
+      recency_weight=1.0,
+)
+
+# Retrieval can be steered with an explicit focal query; when omitted, the most
+# recent entry is used as the query.
+self.memory.get_prompt_ready(query="where is the nearest food source?")
+```
+
 ## Core memory interfaces
 
 ```{eval-rst}

--- a/mesa_llm/memory/episodic_memory.py
+++ b/mesa_llm/memory/episodic_memory.py
@@ -1,4 +1,6 @@
 import json
+import logging
+import math
 from collections import deque
 from typing import TYPE_CHECKING
 
@@ -8,6 +10,8 @@ from mesa_llm.memory.memory import Memory, MemoryEntry, _format_message_entry
 
 if TYPE_CHECKING:
     from mesa_llm.llm_agent import LLMAgent
+
+logger = logging.getLogger(__name__)
 
 
 class EventGrade(BaseModel):
@@ -46,6 +50,27 @@ def normalize_dict_values(scores: dict, min_target: float, max_target: float) ->
     return scores
 
 
+def cosine_similarity(a: list[float], b: list[float]) -> float:
+    """
+    Compute the cosine similarity between two equal-length vectors.
+
+    Returns ``0.0`` when either vector is empty, the lengths differ, or either
+    vector has zero magnitude, so callers can treat it as a safe "no signal"
+    value rather than handling exceptions.
+    """
+    if not a or not b or len(a) != len(b):
+        return 0.0
+
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(y * y for y in b))
+
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+
+    return dot / (norm_a * norm_b)
+
+
 class EpisodicMemory(Memory):
     """
     Event-level memory with LLM-based importance scoring and recency-aware retrieval.
@@ -57,9 +82,12 @@ class EpisodicMemory(Memory):
       https://github.com/joonspk-research/generative_agents/blob/main/reverie/backend_server/persona/cognitive_modules/retrieve.py
 
     This implementation is inspired by the paper's retrieval scoring design
-    (component-wise min-max normalization, then weighted combination). It is
-    not a strict copy of the original code: relevance scoring via embeddings is
-    not implemented yet, and recency is computed from step age.
+    (component-wise min-max normalization, then weighted combination). Retrieval
+    combines importance, recency (computed from step age) and—when an
+    ``embedding_model`` is configured—relevance, scored as the cosine similarity
+    between a focal query and each memory's embedding. Without an
+    ``embedding_model`` the relevance term is skipped and retrieval falls back to
+    importance + recency only.
     """
 
     def __init__(
@@ -71,6 +99,10 @@ class EpisodicMemory(Memory):
         considered_entries: int = 30,
         recency_decay: float = 0.995,
         api_base: str | None = None,
+        embedding_model: str | None = None,
+        recency_weight: float = 1.0,
+        importance_weight: float = 1.0,
+        relevance_weight: float = 1.0,
     ):
         """
         Initialize the EpisodicMemory.
@@ -83,6 +115,13 @@ class EpisodicMemory(Memory):
             considered_entries : number of entries to consider during retrieval
             recency_decay : exponential decay factor for recency scoring
             api_base : the API base URL to use for the LLM provider
+            embedding_model : optional embedding model in ``"{provider}/{model}"``
+                format used to score relevance. When ``None`` the relevance term
+                is disabled and retrieval uses importance + recency only.
+            recency_weight : weight applied to the normalized recency score.
+            importance_weight : weight applied to the normalized importance score.
+            relevance_weight : weight applied to the normalized relevance score
+                (only used when ``embedding_model`` is set).
         """
         if not llm_model:
             raise ValueError(
@@ -100,6 +139,10 @@ class EpisodicMemory(Memory):
         self.memory_entries = deque(maxlen=self.max_capacity)
         self.considered_entries = considered_entries
         self.recency_decay = recency_decay
+        self.embedding_model = embedding_model
+        self.recency_weight = recency_weight
+        self.importance_weight = importance_weight
+        self.relevance_weight = relevance_weight
 
         self.system_prompt = """
             You are an assistant that evaluates memory entries on a scale from 1 to 5, based on their importance to a specific problem or task. Your goal is to assign a score that reflects how much each entry contributes to understanding, solving, or advancing the task. Use the following grading scale:
@@ -187,15 +230,89 @@ class EpisodicMemory(Memory):
         formatted_response = json.loads(rsp.choices[0].message.content)
         return formatted_response["grade"]
 
-    def retrieve_top_k_entries(self, k: int) -> list[MemoryEntry]:
+    def _embed_text(
+        self, text: str | list[str]
+    ) -> list[float] | list[list[float]] | None:
         """
-        Retrieve the top-k entries using normalized importance and recency.
+        Embed one or many texts via the configured embedding model.
+
+        Returns ``None`` (rather than raising) when no embedding model is
+        configured or the embedding call fails, so retrieval can gracefully fall
+        back to importance + recency scoring.
+        """
+        if not self.embedding_model:
+            return None
+        try:
+            return self.llm.embed(text, embedding_model=self.embedding_model)
+        except Exception:
+            logger.warning(
+                "Embedding call failed for model %s; skipping relevance scoring.",
+                self.embedding_model,
+                exc_info=True,
+            )
+            return None
+
+    def _ensure_entry_embeddings(self, entries: list[MemoryEntry]) -> bool:
+        """
+        Populate ``entry.embedding`` for any entries missing it, in one batched
+        embedding call. Returns ``True`` when every entry has an embedding.
+        """
+        missing = [entry for entry in entries if entry.embedding is None]
+        if missing:
+            vectors = self._embed_text([str(entry) for entry in missing])
+            if vectors is None:
+                return False
+            for entry, vector in zip(missing, vectors):
+                entry.embedding = vector
+        return all(entry.embedding is not None for entry in entries)
+
+    def _compute_relevance_scores(
+        self, entries: list[MemoryEntry], query: str | None
+    ) -> dict[int, float] | None:
+        """
+        Score each entry's relevance to the focal query via cosine similarity of
+        embeddings, normalized to ``[0, 1]``.
+
+        The focal query defaults to the most recent entry's text when no explicit
+        query is given. Returns ``None`` when relevance cannot be computed (no
+        embedding model, or an embedding call failed), signalling the caller to
+        skip the relevance term.
+        """
+        query_text = query if query is not None else str(entries[-1])
+        query_embedding = self._embed_text(query_text)
+        if query_embedding is None:
+            return None
+
+        if not self._ensure_entry_embeddings(entries):
+            return None
+
+        relevance = {
+            i: cosine_similarity(query_embedding, entry.embedding)
+            for i, entry in enumerate(entries)
+        }
+        return normalize_dict_values(relevance, 0, 1)
+
+    def retrieve_top_k_entries(
+        self, k: int, query: str | None = None
+    ) -> list[MemoryEntry]:
+        """
+        Retrieve the top-k entries using normalized importance, recency and
+        (when an embedding model is configured) relevance.
+
+        Inspired by Generative Agents retrieval scoring: recency, importance and
+        relevance are normalized separately to ``[0, 1]`` and combined as a
+        weighted sum.
+
+        Args:
+            k : number of entries to return.
+            query : optional focal query used for relevance scoring. When
+                omitted, the most recent entry's text is used as the query.
+                Ignored entirely when no ``embedding_model`` is configured.
 
         Notes:
-        - Inspired by Generative Agents retrieval scoring:
-          recency/importance/relevance are normalized separately and combined.
-        - This implementation currently combines importance + recency only.
-          Relevance (embedding cosine similarity with a focal query) is pending.
+            Relevance is only included when ``embedding_model`` is set and the
+            embedding calls succeed; otherwise retrieval falls back to
+            importance + recency.
         """
         if not self.memory_entries:
             return []
@@ -215,9 +332,18 @@ class EpisodicMemory(Memory):
         importance_scaled = normalize_dict_values(importance_dict, 0, 1)
         recency_scaled = normalize_dict_values(recency_dict, 0, 1)
 
+        relevance_scaled = None
+        if self.embedding_model:
+            relevance_scaled = self._compute_relevance_scores(entries, query)
+
         final_scores = []
         for i in range(len(entries)):
-            total_score = importance_scaled[i] + recency_scaled[i]
+            total_score = (
+                self.importance_weight * importance_scaled[i]
+                + self.recency_weight * recency_scaled[i]
+            )
+            if relevance_scaled is not None:
+                total_score += self.relevance_weight * relevance_scaled[i]
             final_scores.append((total_score, entries[i]))
 
         final_scores.sort(key=lambda x: x[0], reverse=True)
@@ -252,11 +378,22 @@ class EpisodicMemory(Memory):
         }
         self._finalize_entry(type, graded_content)
 
-    def get_prompt_ready(self) -> str:
+    def get_prompt_ready(self, query: str | None = None) -> str:
+        """
+        Format the top retrieved entries for use in a reasoning prompt.
+
+        Args:
+            query : optional focal query forwarded to retrieval for relevance
+                scoring. When omitted, the most recent entry is used as the
+                query (and relevance is only applied when an ``embedding_model``
+                is configured).
+        """
         return f"Top {self.considered_entries} memory entries:\n\n" + "\n".join(
             [
                 str(entry)
-                for entry in self.retrieve_top_k_entries(self.considered_entries)
+                for entry in self.retrieve_top_k_entries(
+                    self.considered_entries, query=query
+                )
             ]
         )
 

--- a/mesa_llm/memory/memory.py
+++ b/mesa_llm/memory/memory.py
@@ -31,11 +31,23 @@ def _format_message_entry(msg_value) -> str:
 class MemoryEntry:
     """
     A data structure that stores individual memory records with content, step number, and agent reference. Each entry includes `rich` formatting for display. Content is a nested dictionary of arbitrary depth containing the entry's information. Each entry is designed to hold all the information of a given step for an agent, but can also be used to store a single event if needed.
+
+    Attributes:
+        content : the (possibly nested) event data for this entry.
+        step : the simulation step the entry belongs to, or ``None`` for a
+            staged pre-step entry.
+        agent : the agent the memory belongs to.
+        embedding : optional cached embedding vector for the entry's text,
+            populated lazily by retrieval-scoring backends (e.g.
+            :class:`~mesa_llm.memory.episodic_memory.EpisodicMemory`) to avoid
+            re-embedding the same entry on every retrieval. ``None`` until
+            computed.
     """
 
     content: dict
     step: int | None
     agent: "LLMAgent"
+    embedding: list[float] | None = None
 
     def __str__(self) -> str:
         """

--- a/mesa_llm/module_llm.py
+++ b/mesa_llm/module_llm.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 from dotenv import load_dotenv
-from litellm import acompletion, completion, litellm
+from litellm import acompletion, aembedding, completion, embedding, litellm
 from litellm.exceptions import (
     APIConnectionError,
     NotFoundError,
@@ -271,3 +271,92 @@ class ModuleLLM:
                         raise self._build_invalid_model_error(error) from error
                     raise
         return response
+
+    @staticmethod
+    def _extract_embeddings(response) -> list[list[float]]:
+        """Pull the embedding vectors out of a LiteLLM embedding response."""
+        return [item["embedding"] for item in response.data]
+
+    @retry(
+        wait=wait_exponential(multiplier=1, min=1, max=60),
+        retry=retry_if_exception_type(RETRYABLE_EXCEPTIONS),
+        reraise=True,
+    )
+    def embed(
+        self,
+        text: str | list[str],
+        embedding_model: str | None = None,
+    ) -> list[float] | list[list[float]]:
+        """
+        Generate embedding vectors for one or more texts via LiteLLM.
+
+        Args:
+            text: A single string or a list of strings to embed.
+            embedding_model: Optional embedding model in ``"{provider}/{model}"``
+                format. Defaults to this module's ``llm_model``; pass a dedicated
+                embedding model (e.g. ``"openai/text-embedding-3-small"``) for
+                meaningful results.
+
+        Returns:
+            A single embedding vector when ``text`` is a string, or a list of
+            vectors (one per input) when ``text`` is a list.
+        """
+        single = isinstance(text, str)
+        inputs = [text] if single else list(text)
+        embedding_kwargs = {
+            "model": embedding_model or self.llm_model,
+            "input": inputs,
+        }
+        if self.api_base:
+            embedding_kwargs["api_base"] = self.api_base
+
+        try:
+            response = embedding(**embedding_kwargs)
+        except RateLimitError as error:
+            raise self._build_rate_limit_error(error) from error
+        except NotFoundError as error:
+            raise self._build_invalid_model_error(error) from error
+        except Exception as error:
+            if str(error).startswith("This model isn't mapped yet."):
+                raise self._build_invalid_model_error(error) from error
+            raise
+
+        vectors = self._extract_embeddings(response)
+        return vectors[0] if single else vectors
+
+    async def aembed(
+        self,
+        text: str | list[str],
+        embedding_model: str | None = None,
+    ) -> list[float] | list[list[float]]:
+        """
+        Asynchronous version of embed() for parallel embedding calls.
+        """
+        single = isinstance(text, str)
+        inputs = [text] if single else list(text)
+        async for attempt in AsyncRetrying(
+            wait=wait_exponential(multiplier=1, min=1, max=60),
+            retry=retry_if_exception_type(RETRYABLE_EXCEPTIONS),
+            reraise=True,
+        ):
+            with attempt:
+                embedding_kwargs = {
+                    "model": embedding_model or self.llm_model,
+                    "input": inputs,
+                }
+                if self.api_base:
+                    embedding_kwargs["api_base"] = self.api_base
+
+                try:
+                    response = await aembedding(**embedding_kwargs)
+                except RateLimitError as error:
+                    raise self._build_rate_limit_error(error) from error
+                except NotFoundError as error:
+                    raise self._build_invalid_model_error(error) from error
+                except Exception as error:
+                    if str(error).startswith("This model isn't mapped yet."):
+                        raise self._build_invalid_model_error(error) from error
+                    raise
+
+        vectors = self._extract_embeddings(response)
+        return vectors[0] if single else vectors

--- a/tests/test_memory/test_episodic_memory.py
+++ b/tests/test_memory/test_episodic_memory.py
@@ -7,6 +7,7 @@ import pytest
 from mesa_llm.memory.episodic_memory import (
     EpisodicMemory,
     EventGrade,
+    cosine_similarity,
     normalize_dict_values,
 )
 from mesa_llm.memory.memory import MemoryEntry
@@ -37,6 +38,20 @@ def test_normalize_dict_floats_logic_when_empty():
     """
     norm = normalize_dict_values({}, 0, 1)
     assert norm == {}
+
+
+def test_cosine_similarity_basic():
+    """cosine_similarity covers identical, orthogonal and opposite vectors."""
+    assert cosine_similarity([1.0, 0.0], [1.0, 0.0]) == 1.0
+    assert cosine_similarity([1.0, 0.0], [0.0, 1.0]) == 0.0
+    assert cosine_similarity([1.0, 0.0], [-1.0, 0.0]) == -1.0
+
+
+def test_cosine_similarity_safe_edge_cases():
+    """cosine_similarity returns 0.0 for empty, mismatched or zero vectors."""
+    assert cosine_similarity([], [1.0]) == 0.0
+    assert cosine_similarity([1.0, 2.0], [1.0]) == 0.0
+    assert cosine_similarity([0.0, 0.0], [1.0, 1.0]) == 0.0
 
 
 class TestEpisodicMemory:
@@ -165,6 +180,129 @@ class TestEpisodicMemory:
         # The highly important memory should win
         assert len(top_entries) == 1
         assert top_entries[0] == entry_a
+
+    def test_retrieve_without_embedding_model_skips_relevance(
+        self, episodic_mock_agent
+    ):
+        """With no embedding_model, retrieval must not call embed() at all."""
+        memory = EpisodicMemory(
+            agent=episodic_mock_agent, llm_model="provider/test_model"
+        )
+        memory.llm.embed = MagicMock()
+        memory.memory_entries.append(
+            MemoryEntry(content={"importance": 3}, step=100, agent=episodic_mock_agent)
+        )
+
+        memory.retrieve_top_k_entries(1, query="anything")
+
+        memory.llm.embed.assert_not_called()
+
+    def test_retrieve_relevance_promotes_similar_entry(self, episodic_mock_agent):
+        """When importance and recency tie, relevance breaks the tie."""
+        memory = EpisodicMemory(
+            agent=episodic_mock_agent,
+            llm_model="provider/test_model",
+            embedding_model="provider/embed",
+        )
+        episodic_mock_agent.model.steps = 10
+
+        # All entries share importance and step, so only relevance differs.
+        relevant = MemoryEntry(
+            content={"importance": 3, "note": "TARGET food location"},
+            step=10,
+            agent=episodic_mock_agent,
+        )
+        other_a = MemoryEntry(
+            content={"importance": 3, "note": "weather chat"},
+            step=10,
+            agent=episodic_mock_agent,
+        )
+        other_b = MemoryEntry(
+            content={"importance": 3, "note": "random walk"},
+            step=10,
+            agent=episodic_mock_agent,
+        )
+        memory.memory_entries.extend([other_a, relevant, other_b])
+
+        def fake_embed(text, embedding_model=None):
+            def vec(t):
+                return [1.0, 0.0] if "TARGET" in t else [0.0, 1.0]
+
+            return [vec(t) for t in text] if isinstance(text, list) else vec(text)
+
+        memory.llm.embed = MagicMock(side_effect=fake_embed)
+
+        top = memory.retrieve_top_k_entries(1, query="where is the TARGET")
+
+        assert top[0] is relevant
+
+    def test_retrieve_caches_entry_embeddings(self, episodic_mock_agent):
+        """Entry embeddings are computed once and cached on the MemoryEntry."""
+        memory = EpisodicMemory(
+            agent=episodic_mock_agent,
+            llm_model="provider/test_model",
+            embedding_model="provider/embed",
+        )
+        episodic_mock_agent.model.steps = 10
+        entry = MemoryEntry(
+            content={"importance": 3, "note": "x"}, step=10, agent=episodic_mock_agent
+        )
+        memory.memory_entries.append(entry)
+
+        calls = []
+
+        def fake_embed(text, embedding_model=None):
+            calls.append(text)
+            return [[1.0, 0.0] for _ in text] if isinstance(text, list) else [1.0, 0.0]
+
+        memory.llm.embed = MagicMock(side_effect=fake_embed)
+
+        memory.retrieve_top_k_entries(1, query="q1")
+        # First retrieval embeds the query (str) and the missing entry (batch list).
+        assert entry.embedding == [1.0, 0.0]
+        first_call_count = memory.llm.embed.call_count
+
+        memory.retrieve_top_k_entries(1, query="q2")
+        # Entry already embedded -> only the query is embedded the second time.
+        assert memory.llm.embed.call_count == first_call_count + 1
+        assert calls[-1] == "q2"
+
+    def test_retrieve_embedding_failure_falls_back_to_importance(
+        self, episodic_mock_agent
+    ):
+        """If embedding raises, retrieval degrades to importance + recency."""
+        memory = EpisodicMemory(
+            agent=episodic_mock_agent,
+            llm_model="provider/test_model",
+            embedding_model="provider/embed",
+        )
+        episodic_mock_agent.model.steps = 10
+        entry_low = MemoryEntry(
+            content={"importance": 1}, step=10, agent=episodic_mock_agent
+        )
+        entry_high = MemoryEntry(
+            content={"importance": 5}, step=10, agent=episodic_mock_agent
+        )
+        memory.memory_entries.extend([entry_low, entry_high])
+
+        memory.llm.embed = MagicMock(side_effect=RuntimeError("boom"))
+
+        top = memory.retrieve_top_k_entries(1, query="q")
+
+        assert top[0] is entry_high
+
+    def test_get_prompt_ready_forwards_query(self, episodic_mock_agent):
+        """get_prompt_ready forwards its query to retrieve_top_k_entries."""
+        memory = EpisodicMemory(
+            agent=episodic_mock_agent, llm_model="provider/test_model"
+        )
+        memory.retrieve_top_k_entries = MagicMock(return_value=[])
+
+        memory.get_prompt_ready(query="focal")
+
+        memory.retrieve_top_k_entries.assert_called_once_with(
+            memory.considered_entries, query="focal"
+        )
 
     def test_process_step_pre_step(self, episodic_mock_agent):
         """

--- a/tests/test_module_llm.py
+++ b/tests/test_module_llm.py
@@ -194,6 +194,75 @@ class TestModuleLLM:
         )
         assert response is not None
 
+    def test_embed_single_and_list(self, monkeypatch):
+        """embed() returns a single vector for a string and a list for a list,
+        defaulting the model to llm_model and forwarding an explicit one."""
+        captured = {}
+
+        def _fake_embedding(**kwargs):
+            captured.clear()
+            captured.update(kwargs)
+            resp = type("R", (), {})()
+            resp.data = [
+                {"embedding": [float(i)] * 3} for i in range(len(kwargs["input"]))
+            ]
+            return resp
+
+        monkeypatch.setattr("mesa_llm.module_llm.embedding", _fake_embedding)
+
+        llm = ModuleLLM(llm_model="openai/gpt-4o")
+
+        # Single string -> single vector, explicit embedding model forwarded.
+        single = llm.embed("hello", embedding_model="openai/text-embedding-3-small")
+        assert single == [0.0, 0.0, 0.0]
+        assert captured["model"] == "openai/text-embedding-3-small"
+        assert captured["input"] == ["hello"]
+
+        # List -> list of vectors, model defaults to llm_model.
+        many = llm.embed(["a", "b"])
+        assert many == [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]
+        assert captured["model"] == "openai/gpt-4o"
+        assert captured["input"] == ["a", "b"]
+
+    def test_embed_forwards_api_base(self, monkeypatch):
+        """embed() forwards api_base when configured (e.g. for Ollama)."""
+        captured = {}
+
+        def _fake_embedding(**kwargs):
+            captured.update(kwargs)
+            resp = type("R", (), {})()
+            resp.data = [{"embedding": [1.0]}]
+            return resp
+
+        monkeypatch.setattr("mesa_llm.module_llm.embedding", _fake_embedding)
+
+        llm = ModuleLLM(llm_model="ollama/llama2")
+        llm.embed("hi")
+        assert captured["api_base"] == "http://localhost:11434"
+
+    @pytest.mark.asyncio
+    async def test_aembed_single_and_list(self, monkeypatch):
+        """aembed() mirrors embed() for single and list inputs."""
+
+        async def _fake_aembedding(**kwargs):
+            resp = type("R", (), {})()
+            resp.data = [
+                {"embedding": [float(i)] * 2} for i in range(len(kwargs["input"]))
+            ]
+            return resp
+
+        monkeypatch.setattr("mesa_llm.module_llm.aembedding", _fake_aembedding)
+
+        llm = ModuleLLM(llm_model="openai/gpt-4o")
+
+        single = await llm.aembed(
+            "hello", embedding_model="openai/text-embedding-3-small"
+        )
+        assert single == [0.0, 0.0]
+
+        many = await llm.aembed(["a", "b"])
+        assert many == [[0.0, 0.0], [1.0, 1.0]]
+
     def test_generate_rewrites_rate_limit_error_with_openai_docs(self, monkeypatch):
         original_error = RateLimitError(
             "per-minute limit hit", "openai", "openai/gpt-4o"


### PR DESCRIPTION
## What

EpisodicMemory retrieval currently combines only importance and recency. Relevance, the third part of the [Generative Agents](https://arxiv.org/abs/2304.03442) retrieval design, is documented in the code as not yet implemented. This PR implements it.

Relevance is the cosine similarity between a focal query and each memory's embedding, normalized to `[0, 1]` and combined with importance and recency as a weighted sum.

## Changes

- `module_llm.py`: add `embed()` / `aembed()` LiteLLM wrappers, matching the existing `generate` / `agenerate` pair. A single string returns one vector; a list returns a list of vectors. Reuses `api_base` and the existing rate-limit / invalid-model error handling and retry/backoff.
- `memory.py`: add an optional `MemoryEntry.embedding` field used to cache an entry's embedding so it is computed once instead of on every retrieval.
- `episodic_memory.py`:
  - add a `cosine_similarity()` helper that returns `0.0` for empty, mismatched-length, or zero vectors;
  - add an `embedding_model` parameter plus `recency_weight`, `importance_weight`, and `relevance_weight`;
  - `retrieve_top_k_entries(k, query=None)` adds a normalized, weighted relevance term when an embedding model is configured, and falls back to importance + recency when it is not (or if an embedding call fails);
  - `get_prompt_ready(query=None)` forwards the focal query, which defaults to the most recent entry's text.
- `docs/apis/memory.md`: usage example for relevance-scored retrieval.

## Backward compatibility

With no `embedding_model` (the default), scoring is identical to before. The existing `test_retrieve_top_k_entries` passes unchanged and no embedding calls are made.

## Tests

Added unit tests for:
- `cosine_similarity` (identical, orthogonal, opposite vectors, and the edge cases);
- `ModuleLLM.embed` / `aembed` (single and list input, model defaulting, `api_base` forwarding);
- relevance breaking ties between entries with equal importance and recency;
- embedding caching (entries embedded once, only the query re-embedded on later retrievals);
- fallback to importance when embedding raises;
- `get_prompt_ready` forwarding the query.

Full suite: 421 passed (was 411). `ruff check` clean, `ruff format` applied.

## Notes

The relevance term is opt-in via `embedding_model`, so current users see no behavior change and no extra embedding cost unless they enable it.
