### PR TITLE
fix(memory): replace Unicode box-drawing chars with ASCII tree markers

### DIFF
--- a/mesa_llm/memory/memory.py
+++ b/mesa_llm/memory/memory.py
@@ -49,24 +49,24 @@ class MemoryEntry:
 
             for key, value in data.items():
                 if isinstance(value, dict):
-                    lines.append(f"{indent}[blue]└──[/blue] [cyan]{key} :[/cyan]")
+                    lines.append(f"{indent}[blue]+--[/blue] [cyan]{key} :[/cyan]")
                     lines.extend(format_nested_dict(value, indent_level + 1))
                 elif isinstance(value, list):
-                    lines.append(f"{indent}[blue]└──[/blue] [cyan]{key} :[/cyan]")
+                    lines.append(f"{indent}[blue]+--[/blue] [cyan]{key} :[/cyan]")
                     next_indent = "   " * (indent_level + 1)
                     for i, item in enumerate(value):
                         if isinstance(item, dict):
                             lines.append(
-                                f"{next_indent}[blue]├──[/blue] [cyan]({i + 1})[/cyan]"
+                                f"{next_indent}[blue]|--[/blue] [cyan]({i + 1})[/cyan]"
                             )
                             lines.extend(format_nested_dict(item, indent_level + 2))
                         else:
                             lines.append(
-                                f"{next_indent}[blue]├──[/blue] [cyan]{item}[/cyan]"
+                                f"{next_indent}[blue]|--[/blue] [cyan]{item}[/cyan]"
                             )
                 else:
                     lines.append(
-                        f"{indent}[blue]└──[/blue] [cyan]{key} : [/cyan]{value}"
+                        f"{indent}[blue]+--[/blue] [cyan]{key} : [/cyan]{value}"
                     )
 
             return lines
@@ -83,11 +83,11 @@ class MemoryEntry:
                     if isinstance(item, dict):
                         lines.extend(format_nested_dict(item, 2))
                     else:
-                        lines.append(f"      [blue]└──[/blue] [cyan]{item}[/cyan]")
+                        lines.append(f"      [blue]+--[/blue] [cyan]{item}[/cyan]")
             elif isinstance(value, dict):
                 lines.extend(format_nested_dict(value, 1))
             else:
-                lines.append(f"   [blue]└──[/blue] [cyan]{value}[/cyan]")
+                lines.append(f"   [blue]+--[/blue] [cyan]{value}[/cyan]")
 
         content = "\n".join(lines)
 

--- a/tests/test_memory/test_memory_encoding.py
+++ b/tests/test_memory/test_memory_encoding.py
@@ -1,0 +1,74 @@
+"""Tests verifying MemoryEntry.__str__() output is encodable on all platforms.
+
+Regression test for https://github.com/mesa/mesa-llm/issues/321 -- the
+box-drawing characters previously used (U+2514, U+2500, U+251C) crash
+with UnicodeEncodeError on Windows cp125x consoles.
+"""
+
+from typing import ClassVar
+
+import pytest
+
+from mesa_llm.memory.memory import MemoryEntry
+
+# Code pages covering all major Windows locale families.
+# Box-drawing chars (U+2514/2500/251C) crash on cp125x; bullet (U+2022)
+# crashes on cp437/850/932/936/949. ASCII tree markers are safe on all.
+WINDOWS_CODEPAGES: list[str] = [
+    "cp1252",  # Western Europe
+    "cp1250",  # Central Europe
+    "cp1251",  # Cyrillic
+    "cp1253",  # Greek
+    "cp1254",  # Turkish
+    "cp1255",  # Hebrew
+    "cp1256",  # Arabic
+    "cp874",  # Thai
+    "cp437",  # DOS US
+    "cp850",  # DOS Western Europe
+    "cp932",  # Japanese
+    "cp936",  # Chinese Simplified
+    "cp949",  # Korean
+    "utf-8",  # Universal
+]
+
+
+@pytest.fixture
+def sample_entry(mock_agent):
+    """Build a MemoryEntry with nested content covering all code paths in __str__."""
+    return MemoryEntry(
+        content={
+            "observation": "price is $20",
+            "action": [{"offer": 25, "targets": ["seller1", "seller2"]}],
+            "message": [{"message": "I offer $25", "sender": 1}],
+            "plan": "negotiate aggressively",
+        },
+        step=1,
+        agent=mock_agent,
+    )
+
+
+class TestMemoryEntryEncoding:
+    """Ensure MemoryEntry.__str__() output never crashes on any encoding."""
+
+    CODEPAGES: ClassVar[list[str]] = WINDOWS_CODEPAGES
+
+    @pytest.mark.parametrize("encoding", CODEPAGES)
+    def test_str_encodable_all_windows_codepages(self, sample_entry, encoding):
+        """MemoryEntry.__str__() output must encode without error on every
+        major Windows code page and UTF-8."""
+        output = str(sample_entry)
+        output.encode(encoding)  # raises UnicodeEncodeError if any char is unsupported
+
+    def test_str_no_box_drawing_characters(self, sample_entry):
+        """No Unicode box-drawing characters (U+2500-U+257F) in output."""
+        output = str(sample_entry)
+        for cp in range(0x2500, 0x2580):
+            assert chr(cp) not in output, (
+                f"Found box-drawing character U+{cp:04X} in MemoryEntry output"
+            )
+
+    def test_str_preserves_tree_structure(self, sample_entry):
+        """Output should still contain ASCII tree markers for hierarchy."""
+        output = str(sample_entry)
+        assert "+--" in output, "Expected ASCII tree marker '+--' in output"
+        assert "|--" in output, "Expected ASCII tree marker '|--' in output"


### PR DESCRIPTION
## Summary

Replaces Unicode box-drawing characters (`└──` U+2514, `──` U+2500, `├──` U+251C) in `MemoryEntry.__str__()` with ASCII tree markers (`+--`, `|--`). These characters caused `UnicodeEncodeError` crashes on Windows cp125x consoles.

Fixes #321

## Changes

- `mesa_llm/memory/memory.py`: Replaced 7 occurrences of `└──`/`├──` with `+--`/`|--` in `MemoryEntry.__str__()`
- `tests/test_memory/test_memory_encoding.py`: New regression test verifying output is encodable across 14 Windows code pages + UTF-8, and that no box-drawing characters (U+2500-U+257F) remain in output

## Problem

`MemoryEntry.__str__()` used literal Unicode box-drawing characters as decorative tree markers in its output. When `display=True` (the default), `Console().print(panel)` writes these to `sys.stdout`. On Windows where `sys.stdout.encoding` is a cp125x variant (Western/Central/Eastern European, Cyrillic, Greek, Turkish, Hebrew, Arabic, Thai), these codepoints have no encoding mapping and raise `UnicodeEncodeError`, crashing the simulation.

This affects all memory backends (`STMemory`, `STLTMemory`, `LTMemory`) since they all call `MemoryEntry.display()`.

Rich's `safe_box` correctly degrades its own panel borders to ASCII on legacy consoles, but the box-drawing characters in `__str__()` are literal content text -- Rich cannot degrade them, so they pass through to `sys.stdout.write()` and fail.

## Solution

ASCII tree markers (`+--`, `|--`) are pure ASCII (bytes 0x2B, 0x2D, 0x7C). Safe in every encoding ever created. Preserves the tree hierarchy that `└──`/`├──` provided.

### Options considered

| Option | cp125x | cp437/850 | cp932/936/949 | Verdict |
|---|---|---|---|---|
| `└──` (current) | CRASH | safe | safe | broken |
| `•` (U+2022) | safe | CRASH | CRASH | trades one crash for another |
| `+--` (ASCII) | safe | safe | safe | universally safe |

### Before / After

Before:
```
[Observation]
   └── price : $20
   └── seller : Bob
[Action]
   ├── (1)
   │  └── offer : $25
   ├── (2)
```

After:
```
[Observation]
   +-- price : $20
   +-- seller : Bob
[Action]
   |-- (1)
   |   +-- offer : $25
   |-- (2)
```

<img width="1674" height="817" alt="Screenshot 2026-08-08 023822" src="https://github.com/user-attachments/assets/f0559b6e-a8ce-44a7-bc2a-5e4f133ea3af" />

## Testing

- All 121 existing memory tests pass
- 16 new encoding tests pass (14 parametrized code page tests + box-drawing absence + tree structure preservation)
- `pre-commit run --all-files` passes (ruff, ruff-format, pyupgrade, codespell)

```bash
python -m pytest tests/test_memory/ -v --timeout=30
# 137 passed
```