### PR TITLE
fix(memory): render real communication history in LongTermMemory

### DIFF
--- a/mesa_llm/memory/lt_memory.py
+++ b/mesa_llm/memory/lt_memory.py
@@ -1,6 +1,7 @@
+from collections import deque
 from typing import TYPE_CHECKING
 
-from mesa_llm.memory.memory import Memory, MemoryEntry
+from mesa_llm.memory.memory import Memory, MemoryEntry, _format_message_entry
 
 if TYPE_CHECKING:
     from mesa_llm.llm_agent import LLMAgent
@@ -16,7 +17,15 @@ class LongTermMemory(Memory):
         llm_model : the model to use for the summarization
         additive_event_types : event types accumulated as lists within a step.
             Defaults to ``{"message", "action"}``.
+        communication_history_capacity : maximum number of message events
+            retained for ``get_communication_history()``. Defaults to 50.
 
+    Note
+        Consolidation summarizes each step into a single long-term string,
+        which discards the structure of individual messages. Message events are
+        therefore additionally retained in a bounded log so that the
+        communication history stays readable, mirroring the behaviour of the
+        other memory backends.
     """
 
     def __init__(
@@ -26,6 +35,7 @@ class LongTermMemory(Memory):
         llm_model: str = "openai/gpt-4o-mini",
         api_base: str | None = None,
         additive_event_types: list[str] | set[str] | tuple[str, ...] | None = None,
+        communication_history_capacity: int = 50,
     ):
         """
         Initialize long-term memory.
@@ -38,11 +48,21 @@ class LongTermMemory(Memory):
             additive_event_types : event types that accumulate multiple values
                 within a step instead of overwriting. Defaults to
                 ``{"message", "action"}``.
+            communication_history_capacity : maximum number of message events
+                retained for ``get_communication_history()``. Older messages are
+                discarded once the limit is reached.
+
+        Raises:
+            ValueError: If llm_model is falsy, or if
+                communication_history_capacity is less than 1.
         """
         if not llm_model:
             raise ValueError(
                 "llm_model must be provided for the usage of long term memory"
             )
+
+        if communication_history_capacity < 1:
+            raise ValueError("communication_history_capacity must be >= 1")
 
         super().__init__(
             agent=agent,
@@ -53,6 +73,9 @@ class LongTermMemory(Memory):
         )
 
         self.long_term_memory = ""
+        self.communication_history: deque[MemoryEntry] = deque(
+            maxlen=communication_history_capacity
+        )
         self.system_prompt = """
             You are a helpful assistant that summarizes all memory entries and stores it into long-term.
             The long term memory should be a summary of the individual memory entries such that it is concise and informative.
@@ -62,6 +85,33 @@ class LongTermMemory(Memory):
             self.system_prompt += f" This is the prompt of the problem you will be tackling:{self.agent.step_prompt}, ensure you summarize the memory entries into long-term a way that is relevant to the problem at hand."
 
         self.llm.system_prompt = self.system_prompt
+
+    def add_to_memory(self, type: str, content: dict):
+        """
+        Record an event and retain message events for the communication history.
+
+        Consolidation folds each step into a single long-term summary string,
+        so the structure of individual messages does not survive. Message
+        events are therefore also appended to a bounded log, stamped with the
+        step in which they were recorded.
+
+        Args:
+            type : the event type, for example "message" or "plan"
+            content : the event payload
+
+        Raises:
+            TypeError: If content is not a dict.
+        """
+        super().add_to_memory(type, content)
+
+        if type == "message":
+            self.communication_history.append(
+                MemoryEntry(
+                    agent=self.agent,
+                    content={"message": content},
+                    step=self.agent.model.steps,
+                )
+            )
 
     def _build_consolidation_prompt(self) -> str:
         """
@@ -172,5 +222,20 @@ class LongTermMemory(Memory):
     def get_communication_history(self) -> str:
         """
         Get the communication history
+
+        Returns:
+            One entry per message, formatted as
+            "Step {step}: Agent {sender} says: {text}", or an empty string when
+            no messages have been exchanged.
         """
-        return "communication history is in memory of the agent"
+        lines = []
+        for entry in self.communication_history:
+            if "message" not in entry.content:
+                continue
+            msgs = entry.content["message"]
+            if isinstance(msgs, list):
+                for msg in msgs:
+                    lines.append(f"Step {entry.step}: {_format_message_entry(msg)}\n\n")
+            else:
+                lines.append(f"Step {entry.step}: {_format_message_entry(msgs)}\n\n")
+        return "\n".join(lines)

--- a/tests/test_memory/test_lt_memory.py
+++ b/tests/test_memory/test_lt_memory.py
@@ -4,6 +4,8 @@ import pytest
 
 from mesa_llm.memory.lt_memory import LongTermMemory
 from mesa_llm.memory.memory import MemoryEntry
+from mesa_llm.reasoning.react import ReActReasoning
+from mesa_llm.reasoning.reasoning import Observation
 
 
 class TestLTMemory:
@@ -151,3 +153,184 @@ class TestLTMemory:
             assert memory.long_term_memory == "mocked async summary"
             assert memory.step_content == {}
             assert memory.buffer.step is not None
+
+
+class TestLTMemoryCommunicationHistory:
+    """Regression tests for LongTermMemory.get_communication_history().
+
+    LongTermMemory previously returned the hardcoded placeholder
+    "communication history is in memory of the agent", unlike ShortTermMemory,
+    STLTMemory and EpisodicMemory which all render readable message text. The
+    placeholder was always truthy, so ReActReasoning injected it into every
+    prompt. See issue #327.
+    """
+
+    def _memory(self, mock_agent, **kwargs):
+        return LongTermMemory(
+            agent=mock_agent,
+            llm_model="provider/test_model",
+            display=False,
+            **kwargs,
+        )
+
+    def test_get_communication_history_nested_dict(self, mock_agent):
+        """The nested dict produced by speak_to renders as readable text."""
+        memory = self._memory(mock_agent)
+
+        memory.add_to_memory(
+            type="message",
+            content={
+                "message": "meet me at the north",
+                "sender": 7,
+                "recipients": [1],
+            },
+        )
+
+        history = memory.get_communication_history()
+
+        assert "Agent 7 says: meet me at the north" in history
+        assert "Step 1:" in history
+        assert "communication history is in memory of the agent" not in history
+
+    def test_get_communication_history_multiple_messages(self, mock_agent):
+        """Several messages in one step each produce their own line."""
+        memory = self._memory(mock_agent)
+
+        memory.add_to_memory(
+            type="message",
+            content={"message": "first", "sender": 1, "recipients": [2]},
+        )
+        memory.add_to_memory(
+            type="message",
+            content={"message": "second", "sender": 2, "recipients": [1]},
+        )
+
+        history = memory.get_communication_history()
+
+        assert "Agent 1 says: first" in history
+        assert "Agent 2 says: second" in history
+
+    def test_get_communication_history_list_entry(self, mock_agent):
+        """A directly appended list-valued entry renders one line per message."""
+        memory = self._memory(mock_agent)
+
+        memory.communication_history.append(
+            MemoryEntry(
+                agent=mock_agent,
+                content={
+                    "message": [
+                        {"message": "first", "sender": 1, "recipients": [2]},
+                        {"message": "second", "sender": 2, "recipients": [1]},
+                    ]
+                },
+                step=4,
+            )
+        )
+
+        history = memory.get_communication_history()
+
+        assert "Step 4: Agent 1 says: first" in history
+        assert "Step 4: Agent 2 says: second" in history
+
+    def test_get_communication_history_skips_non_message_entries(self, mock_agent):
+        """Plans and observations must not leak into the communication history."""
+        memory = self._memory(mock_agent)
+
+        memory.add_to_memory(type="plan", content={"content": "Test plan"})
+        memory.add_to_memory(type="observation", content={"content": "Test obs"})
+        memory.add_to_memory(
+            type="message",
+            content={"message": "only this", "sender": 3, "recipients": [1]},
+        )
+
+        history = memory.get_communication_history()
+
+        assert "Agent 3 says: only this" in history
+        assert "Test plan" not in history
+        assert "Test obs" not in history
+
+    def test_get_communication_history_returns_empty_string_when_no_messages(
+        self, mock_agent
+    ):
+        """No messages must yield a falsy string, not the old placeholder.
+
+        This is what stops ReActReasoning from appending an empty
+        "last communication:" section on every step.
+        """
+        memory = self._memory(mock_agent)
+
+        memory.add_to_memory(type="plan", content={"content": "Test plan"})
+
+        assert memory.get_communication_history() == ""
+        assert not memory.get_communication_history()
+
+    def test_communication_history_is_bounded(self, mock_agent):
+        """The log is bounded, so long simulations cannot grow it without limit."""
+        memory = self._memory(mock_agent, communication_history_capacity=3)
+
+        for i in range(5):
+            memory.add_to_memory(
+                type="message",
+                content={"message": f"msg-{i}", "sender": i, "recipients": [9]},
+            )
+
+        history = memory.get_communication_history()
+
+        assert len(memory.communication_history) == 3
+        assert "msg-0" not in history
+        assert "msg-1" not in history
+        assert "msg-2" in history
+        assert "msg-4" in history
+
+    def test_invalid_communication_history_capacity_raises(self, mock_agent):
+        """Capacity below 1 would silently discard every message."""
+        with pytest.raises(ValueError, match="communication_history_capacity"):
+            self._memory(mock_agent, communication_history_capacity=0)
+
+    @pytest.mark.asyncio
+    async def test_async_add_to_memory_records_communication(self, mock_agent):
+        """The async path delegates to add_to_memory, so it records too."""
+        memory = self._memory(mock_agent)
+
+        await memory.aadd_to_memory(
+            type="message",
+            content={"message": "async hello", "sender": 5, "recipients": [1]},
+        )
+
+        history = memory.get_communication_history()
+
+        assert "Agent 5 says: async hello" in history
+
+    def test_add_to_memory_still_rejects_non_dict_content(self, mock_agent):
+        """Base-class validation runs before anything is logged."""
+        memory = self._memory(mock_agent)
+
+        with pytest.raises(TypeError):
+            memory.add_to_memory(type="message", content="not a dict")
+
+        assert len(memory.communication_history) == 0
+
+    def test_react_prompt_omits_section_when_history_empty(self, mock_agent):
+        """ReActReasoning must not append a 'last communication' section.
+
+        Previously the placeholder string was always truthy, so the section was
+        appended to every prompt with meaningless content.
+        """
+        memory = self._memory(mock_agent)
+        mock_agent.memory = memory
+
+        reasoning = ReActReasoning(agent=mock_agent)
+        obs = Observation(step=1, self_state={}, local_state={})
+
+        prompt_list = reasoning.get_react_prompt(obs)
+
+        assert not any("last communication" in part for part in prompt_list)
+
+        memory.add_to_memory(
+            type="message",
+            content={"message": "ping", "sender": 2, "recipients": [1]},
+        )
+        prompt_list = reasoning.get_react_prompt(obs)
+
+        assert any("last communication" in part for part in prompt_list)
+        assert any("Agent 2 says: ping" in part for part in prompt_list)


### PR DESCRIPTION
## Summary

Closes #327.

`LongTermMemory.get_communication_history()` returned a hardcoded placeholder string instead of the agent's actual message history:

```python
return "communication history is in memory of the agent"
```

`ShortTermMemory`, `STLTMemory`, and `EpisodicMemory` all render readable message text via the shared `_format_message_entry()` helper. `LongTermMemory` was the only `Memory` subclass that did not.

This matters because `ReActReasoning.get_react_prompt()` calls the method on every planning step and appends the result behind a truthiness check (`react.py:63`). For the other three backends an agent with no messages yields `""`, which is falsy, so nothing is appended. The placeholder is *always* truthy — so a `LongTermMemory` + `ReActReasoning` agent had this injected into **every prompt, on every step**:

```
last communication:
communication history is in memory of the agent
```

That occupies the slot where inter-agent dialogue belongs, and feeds the model an instruction-shaped string as if it were observed data. Same failure mode as #193, different root cause: #193's scope explicitly listed only the other three backends, and `LongTermMemory` was missed because its implementation was a stub rather than a visibly broken f-string.

## Changes

- Added a bounded `communication_history` deque to `LongTermMemory`, sized by a new `communication_history_capacity` parameter (default 50).
- Overrode `add_to_memory()` to call `super()` **first** — so the base class's non-dict `TypeError` validation runs before anything is logged — then append message-typed events to the log.
- Replaced the stub `get_communication_history()` with the same formatting loop the other three backends use.

The summarization path is untouched, so existing `LongTermMemory` behavior and tests are unaffected.

### Why a separate log was needed

Unlike its siblings, `LongTermMemory` deliberately collapses each step into an LLM-generated summary string and retains only a single-step `buffer`. Once `_update_long_term_memory()` runs, the structured `{"message": ..., "sender": ...}` payload is gone — dissolved into prose. There is nothing left to format, which is presumably why the method was stubbed in the first place. Fixing it therefore required retaining message events separately; the log is bounded so long simulations cannot grow it without limit.

## Design decisions worth flagging

**Add-time step stamping.** The other backends stamp `step` at *finalization* (entries are `step=None` while staging). This PR stamps at *add time* from `self.agent.model.steps`, following the precedent already set by `EpisodicMemory._finalize_entry()` — the closest sibling, since it likewise persists at add-time rather than through the two-phase pre/post-step buffer. The alternative (stamp `None`, backfill in `process_step()`) would be more faithful to `LongTermMemory`'s own staging model but adds a second moving part for no visible gain. Happy to switch if you prefer the latter.

**`capacity < 1` guard.** `communication_history_capacity=0` would produce `deque(maxlen=0)`, silently discarding every message while appearing to work. The constructor now raises `ValueError` for values below 1, mirroring `ShortTermMemory`'s existing `n must be >= 1` check.

**The `isinstance(msgs, list)` branch is currently unreachable via the public API.** In this design each `add_to_memory()` call creates its own entry, so `msgs` is always a dict — the list branch only triggers for entries appended directly to the deque. It is kept deliberately, so the method is character-identical to `EpisodicMemory.get_communication_history()`, which is the cross-backend consistency this issue is about. Happy to drop it if you would rather not carry unreachable code.

## Tests

Added 10 tests in `tests/test_memory/test_lt_memory.py`, which previously had **no** coverage of this method at all, while each of the other three backends already had four regression tests for it.

The two that actually pin the bug shut:

- `test_get_communication_history_returns_empty_string_when_no_messages` — asserts the result is falsy, not a truthy placeholder.
- `test_react_prompt_omits_section_when_history_empty` — asserts `ReActReasoning.get_react_prompt()` omits the `last communication` section entirely when there is no history, and includes it once a message exists.

The rest cover the nested-dict payload produced by `speak_to`, multiple messages, the list branch, skipping non-message entries, the capacity bound, the `capacity < 1` guard, the async path, and that non-dict content is still rejected before anything is logged.

No async override was needed: `Memory.aadd_to_memory()` delegates to the sync method, so overriding `add_to_memory()` covers both paths. `test_async_add_to_memory_records_communication` locks that in.

## Verification

`pytest --cov=mesa_llm tests/` — suite green, **1211 → 1221 tests**, zero failures.

| | Before | After |
| --- | --- | --- |
| `lt_memory.py` | 63 stmts, 4 missed, **94%** | 80 stmts, 3 missed, **96%** |
| Project total | 3227 stmts, 258 missed, **92%** | 3244 stmts, 257 missed, **92%** |

`lt_memory.py`'s uncovered lines moved from `6, 43, 170, 176` to `7, 60, 234` — line 176 was the stub's `return` and is now covered. The three remaining are pre-existing and unrelated (a `TYPE_CHECKING` import, the `llm_model` guard, and `get_prompt_ready()`); I left them alone as out of scope. Total missed statements dropped by one despite adding 17 statements, and every other module's coverage is unchanged.

`pre-commit run --all-files` passes on all seven hooks.
